### PR TITLE
Use current `chainId` for `signTypedData` instead of `3`

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -269,6 +269,9 @@ const initialize = () => {
     }
 
     signTypedData.onclick = () => {
+      const networkId = parseInt(networkDiv.innerHTML)
+      const chainId = parseInt(chainIdDiv.innerHTML) || networkId
+
       const typedData = {
         types: {
           EIP712Domain: [
@@ -291,7 +294,7 @@ const initialize = () => {
         domain: {
           name: 'Ether Mail',
           version: '1',
-          chainId: 3,
+          chainId,
           verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
         },
         message: {


### PR DESCRIPTION
Instead of using the `chainId` "3" for the `signTypedData` button (i.e. Ropsten), the test dapp will now use the `chainId` of whichever network is currently selected (falling back to the `networkId` if there is no `chainId`).

This reconciles this repository with the test-dapp in `metamask-extension, which was recently changed: https://github.com/MetaMask/metamask-extension/pull/7859