### PR TITLE
Update test dapp

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -66,6 +66,7 @@ const initialize = () => {
   }
   let accounts
   let piggybankContract
+  let accountButtonsInitialized = false
 
   const accountButtons = [
     deployButton,
@@ -119,6 +120,12 @@ const initialize = () => {
   }
 
   const initializeAccountButtons = () => {
+
+    if (accountButtonsInitialized) {
+      return
+    }
+    accountButtonsInitialized = true
+
     piggybankContract = web3.eth.contract([{ 'constant': false, 'inputs': [{ 'name': 'withdrawAmount', 'type': 'uint256' }], 'name': 'withdraw', 'outputs': [{ 'name': 'remainingBal', 'type': 'uint256' }], 'payable': false, 'stateMutability': 'nonpayable', 'type': 'function' }, { 'constant': true, 'inputs': [], 'name': 'owner', 'outputs': [{ 'name': '', 'type': 'address' }], 'payable': false, 'stateMutability': 'view', 'type': 'function' }, { 'constant': false, 'inputs': [], 'name': 'deposit', 'outputs': [{ 'name': '', 'type': 'uint256' }], 'payable': true, 'stateMutability': 'payable', 'type': 'function' }, { 'inputs': [], 'payable': false, 'stateMutability': 'nonpayable', 'type': 'constructor' }])
     deployButton.onclick = async () => {
       contractStatus.innerHTML = 'Deploying'

--- a/contract.js
+++ b/contract.js
@@ -66,7 +66,6 @@ const initialize = () => {
   }
   let accounts
   let piggybankContract
-  let connected = false
 
   const accountButtons = [
     deployButton,
@@ -334,8 +333,7 @@ const initialize = () => {
   const handleNewAccounts = (newAccounts) => {
     accounts = newAccounts
     accountsDiv.innerHTML = accounts
-    if (!connected && accounts && accounts.length) {
-      connected = true
+    if (isMetaMaskConnected()) {
       initializeAccountButtons()
     }
     updateButtons()
@@ -369,16 +367,17 @@ const initialize = () => {
 
   const onClickConnect = async () => {
     try {
-      handleNewAccounts(await ethereum.enable())
+      await ethereum.enable()
     } catch (error) {
       console.error(error)
     }
-    getNetworkAndChainId()
   }
 
   updateButtons()
+
   if (isMetaMaskInstalled()) {
     ethereum.autoRefreshOnNetworkChange = false
+    getNetworkAndChainId()
     ethereum.on('chainIdChanged', handleNewChain)
     ethereum.on('networkChanged', handleNewNetwork)
     ethereum.on('accountsChanged', handleNewAccounts)

--- a/deploy.sh
+++ b/deploy.sh
@@ -80,6 +80,7 @@ function preprocess_and_publish {
   # the "-u" here is if the branch was created
   git push -u "${GH_REMOTE}" "${DEPLOY_BRANCH}" || abort "Failed to push to '${GH_REMOTE}/${DEPLOY_BRANCH}'"
   echo "Successfully pushed to ${GH_REMOTE}/${DEPLOY_BRANCH}"
+  git checkout "${SOURCE_BRANCH}" || abort "Failed to checkout source branch after publishing"
 }
 
 function main {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "deploy": "./deploy.sh",
     "lint": "eslint . --ext js,json",
     "lint:fix": "eslint . --fix --ext js,json",
-    "start": "static-server . --port 9010",
+    "serve": "static-server . --port 9011",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Fixes strange test dapp behavior. It should now be compatible with the old and new inpage providers. I've done basic manual testing with both.

In sum:
- Successfully retrieves Ethereum accounts with new and old inpage providers
- Updates accounts, networkId, and chainId always if possible
- `window.ethereum` -> `ethereum`
- Minor fixes to deploy script and package.json