### PR TITLE
Fix lint issue in contract.js

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -89,6 +89,14 @@ const initialize = () => {
     onboarding.startOnboarding()
   }
 
+  const onClickConnect = async () => {
+    try {
+      await ethereum.enable()
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
   const updateButtons = () => {
     const accountButtonsDisabled = !isMetaMaskInstalled() || !isMetaMaskConnected()
     if (accountButtonsDisabled) {
@@ -370,14 +378,6 @@ const initialize = () => {
         handleNewNetwork(response.result)
       }
     })
-  }
-
-  const onClickConnect = async () => {
-    try {
-      await ethereum.enable()
-    } catch (error) {
-      console.error(error)
-    }
   }
 
   updateButtons()


### PR DESCRIPTION
This PR fixes the outstanding lint issue. (We should add the lint to the CI?)

```
yarn run v1.21.1
$ eslint . --ext js,json

metamask-test-dapp/contract.js
  117:31  error  'onClickConnect' was used before it was defined  no-use-before-define

✖ 1 problem (1 error, 0 warnings)

```