### PR TITLE
remove contract status from non contract cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,6 @@
             <div class="card-body">
               <h4 class="card-title">Send Eth</h4>
               <button class="btn btn-primary btn-lg btn-block mb-3" id="sendButton" disabled>Send</button>
-              <p class="info-text alert alert-info">Contract Status: <span id="contractStatus">Not clicked</span></p>
               <hr />
               <h4>Sign Typed Data</h4>
               <button class="btn btn-primary btn-lg btn-block mb-3" id="signTypedData" disabled>Sign</button>
@@ -90,7 +89,6 @@
                 Without Gas</button>
               <button class="btn btn-primary btn-lg btn-block mb-3" id="approveTokensWithoutGas" disabled>Approve Tokens
                 Without Gas</button>
-              <p class="info-text alert alert-info">Contract Status: <span id="contractStatus">Not clicked</span></p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
there were two contractStatus spans that were likely remnants from the contract deploy card, which has a status indicator on the different stages the contracts was in. the send and the deploy token don't have any status tracking