### PR TITLE
Rename script: serve -> start

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "deploy": "./deploy.sh",
     "lint": "eslint . --ext js,json",
     "lint:fix": "eslint . --fix --ext js,json",
-    "serve": "static-server . --port 9011",
+    "start": "static-server . --port 9011",
     "test": "yarn lint"
   },
   "repository": {


### PR DESCRIPTION
In a moment of poor judgment, I named the start script `serve` instead of `start`. This PR rectifies this mistake.