### PR TITLE
Add publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "start": "static-server ./website --port 9011",
     "test": "yarn lint"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/MetaMask/test-dapp.git"


### PR DESCRIPTION
This is an org-scoped package, so adding `publishConfig` to package.json to avoid having to explicitly add `--access=public` to `npm publish`.