### PR TITLE
Move all globals into ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,12 @@ module.exports = {
     'browser': true,
   },
 
+  globals: {
+    'web3': 'readonly',
+    'ethereum': 'readonly',
+    'MetamaskOnboarding': 'readonly',
+  },
+
   plugins: [
     'json',
   ],
@@ -27,8 +33,4 @@ module.exports = {
     '@metamask/eslint-config',
     '@metamask/eslint-config/config/nodejs',
   ],
-
-  globals: {
-    'web3': true,
-  },
 }

--- a/website/index.js
+++ b/website/index.js
@@ -1,5 +1,3 @@
-/*global ethereum, MetamaskOnboarding */
-
 /*
 The `piggybankContract` is compiled from:
 


### PR DESCRIPTION
This PR consolidates the ESLint config into the, er, ESLint config (`.eslintrc.js`)