### PR TITLE
Fix locally serving onboarding bundle

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,4 +31,8 @@ module.exports = {
   globals: {
     'web3': true,
   },
+
+  ignorePatterns: [
+    '*bundle.js',
+  ],
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 node_modules
 .vscode
+metamask-onboarding.bundle.js

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,7 +37,7 @@ function is_working_tree_dirty {
 
 # for gh-pages, use unpkg.com for dependencies
 function replace_onboarding_src {
-  local local_src="../node_modules/@metamask/onboarding/dist/metamask-onboarding.bundle.js"
+  local local_src="./metamask-onboarding.bundle.js"
   local web_src="https://unpkg.com/@metamask/onboarding@0.2.1/dist/metamask-onboarding.bundle.js"
   local target_file="${WEBSITE_DIR_PATH}/index.html"
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint . --ext js,json && prettier ./website -c",
     "lint:fix": "eslint . --fix --ext js,json && prettier ./website -c --write",
     "start": "static-server ./website --port 9011",
+    "postinstall": "cp ./node_modules/@metamask/onboarding/dist/metamask-onboarding.bundle.js ./website",
     "test": "yarn lint"
   },
   "publishConfig": {

--- a/website/index.html
+++ b/website/index.html
@@ -227,10 +227,7 @@
       </section>
     </main>
 
-    <script
-      src="../node_modules/@metamask/onboarding/dist/metamask-onboarding.bundle.js"
-      defer
-    ></script>
+    <script src="./metamask-onboarding.bundle.js" defer></script>
     <script src="index.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Recent work accidentally broke the import of the onboarding bundle when serving the site locally. This PR fixes this by means of a `postinstall` script.