### PR TITLE
Add permissions actions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-!.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,8 @@ module.exports = {
     '@metamask/eslint-config/config/nodejs',
   ],
   ignorePatterns: [
+    '!.eslintrc.js',
     '*bundle.js',
+    '*min.js',
   ],
 }

--- a/website/index.html
+++ b/website/index.html
@@ -89,6 +89,38 @@
       </section>
 
       <section>
+        <div class="row d-flex justify-content-center">
+          <div class="col-xl-4 col-lg-6 col-md-12 col-sm-12 col-12">
+            <div class="card">
+              <div class="card-body">
+                <h4 class="card-title">
+                  Permissions Actions
+                </h4>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="requestPermissions"
+                >
+                  Request Permissions
+                </button>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="getPermissions"
+                >
+                  Get Permissions
+                </button>
+
+                <p class="info-text alert alert-secondary">
+                  Permissions result: <span id="permissionsResult"></span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
         <div class="row">
           <div
             class="col-xl-4 col-lg-6 col-md-12 col-sm-12 col-12 d-flex align-items-stretch"

--- a/website/index.js
+++ b/website/index.js
@@ -45,6 +45,11 @@ const onboardButton = document.getElementById('connectButton')
 const getAccountsButton = document.getElementById('getAccounts')
 const getAccountsResults = document.getElementById('getAccountsResult')
 
+// Permissions Actions Section
+const requestPermissionsButton = document.getElementById('requestPermissions')
+const getPermissionsButton = document.getElementById('getPermissions')
+const permissionsResult = document.getElementById('permissionsResult')
+
 // Contract Section
 const deployButton = document.getElementById('deployButton')
 const depositButton = document.getElementById('depositButton')
@@ -346,6 +351,31 @@ const initialize = async () => {
       }
     }
 
+    requestPermissionsButton.onclick = async () => {
+      try {
+        const permissionsArray = await ethereum.request({
+          method: 'wallet_requestPermissions',
+          params: [{ eth_accounts: {} }],
+        })
+        permissionsResult.innerHTML = getPermissionsDisplayString(permissionsArray)
+      } catch (err) {
+        console.error(err)
+        permissionsResult.innerHTML = `Error: ${err.message}`
+      }
+    }
+
+    getPermissionsButton.onclick = async () => {
+      try {
+        const permissionsArray = await ethereum.request({
+          method: 'wallet_getPermissions',
+        })
+        permissionsResult.innerHTML = getPermissionsDisplayString(permissionsArray)
+      } catch (err) {
+        console.error(err)
+        permissionsResult.innerHTML = `Error: ${err.message}`
+      }
+    }
+
     getAccountsButton.onclick = async () => {
       try {
         const _accounts = await ethereum.request({
@@ -415,3 +445,12 @@ const initialize = async () => {
 }
 
 window.addEventListener('DOMContentLoaded', initialize)
+
+function getPermissionsDisplayString (permissionsArray) {
+  if (permissionsArray.length === 0) {
+    return 'No permissions found.'
+  }
+  const permissionNames = permissionsArray.map((perm) => perm.parentCapability)
+  return permissionNames.reduce((acc, name) => `${acc}${name}, `, '').replace(/, $/u, '')
+}
+


### PR DESCRIPTION
Adds actions for `rpc-cap` RPC methods:
- `wallet_requestPermissions`
  - This method always requests the `eth_accounts` permission
  - We can discuss if we want to add buttons with other actions, but we can also manually `ethereum.request` stuff
- `wallet_getPermissions`

Minor fixup
- Delete `.eslintignore`, update `ignorePatterns` in `.eslintrc.js`