### PR TITLE
Only use `localhost` forwarder on `localhost`

### DIFF
--- a/website/index.js
+++ b/website/index.js
@@ -28,7 +28,10 @@ The `piggybankContract` is compiled from:
   }
 */
 
-const forwarderOrigin = 'http://localhost:9010'
+const currentUrl = new URL(window.location.href)
+const forwarderOrigin = currentUrl.hostname === 'localhost'
+  ? 'http://localhost:9010'
+  : undefined
 
 const isMetaMaskInstalled = () => {
   const { ethereum } = window


### PR DESCRIPTION
The hosted version of the test dapp was erroneously referencing a forwarder hosted on `localhost`. The `forwarderOrigin` option should only be specified if a non-default forwarder is wanted (e.g. when
testing locally).