### PR TITLE
v2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "scripts": {
     "deploy": "./deploy.sh",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/MetaMask/test-dapp.git"
   },
   "files": [
-    "/website"
+    "website/"
   ],
   "author": "MetaMask",
   "license": "MIT",


### PR DESCRIPTION
- `2.1.0`
- Fix annoying, if meaningless, typo in `package.json` `files` array

The extension has been tested with this version of the test dapp, and it works.