### PR TITLE
Fix eth-sig-util import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ The `piggybankContract` is compiled from:
   }
 */
 
-import sigUtil from 'eth-sig-util'
+import { encrypt } from 'eth-sig-util'
 import MetaMaskOnboarding from '@metamask/onboarding'
 
 const currentUrl = new URL(window.location.href)
@@ -471,7 +471,7 @@ const initialize = async () => {
     encryptButton.onclick = () => {
       try {
         ciphertextDisplay.innerText = web3.toHex(JSON.stringify(
-          sigUtil.encrypt(
+          encrypt(
             encryptionKeyDisplay.innerText,
             { 'data': encryptMessageInput.value },
             'x25519-xsalsa20-poly1305',


### PR DESCRIPTION
The `eth-sig-util` import was broken in #63 because it switch from using `require` to `import`. `eth-sig-util` has no default export, so the `sigUtil` variable was getting assigned to `undefined`.

The named export is now used.