### PR TITLE
Skip lint and build upon install

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -53,7 +53,8 @@ function get_shorthash {
 
 function preprocess_and_publish {
 
-  yarn prepare
+  yarn lint || abort "Lint failure"
+  yarn build || abort "Failed to build"
 
   local shorthash
   shorthash=$(get_shorthash)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "webpack-dev-server",
     "build": "webpack --mode production",
     "test": "yarn lint",
-    "prepare": "yarn test && yarn build"
+    "prepublishOnly": "yarn test && yarn build"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Previously `yarn lint` and `yarn build` would get called upon install. I found this to be unnecessary and inconvenient. The `prepare` script that caused this has been replaced with a `prepublishOnly` script, so that it still runs before publish but not upon each install.

The old `prepare` script was also used during deployment, though worryingly we didn't handle the case where it fails. `yarn lint` and `yarn build` are now called separately during the deploy script, and we handle failures for either.