### PR TITLE
Fix onboarding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,20 +5,9 @@ import { ethers } from 'ethers'
 import { toChecksumAddress } from 'ethereumjs-util'
 import { hstBytecode, hstAbi, piggybankBytecode, piggybankAbi } from './constants.json'
 
-// We must specify the network as 'any' for ethers to allow network changes
-const ethersProvider = new ethers.providers.Web3Provider(window.ethereum, 'any')
-
-const hstFactory = new ethers.ContractFactory(
-  hstAbi,
-  hstBytecode,
-  ethersProvider.getSigner(),
-)
-
-const piggybankFactory = new ethers.ContractFactory(
-  piggybankAbi,
-  piggybankBytecode,
-  ethersProvider.getSigner(),
-)
+let ethersProvider
+let hstFactory
+let piggybankFactory
 
 const currentUrl = new URL(window.location.href)
 const forwarderOrigin = currentUrl.hostname === 'localhost'
@@ -90,6 +79,22 @@ const signTypedDataV4Verify = document.getElementById('signTypedDataV4Verify')
 const signTypedDataV4VerifyResult = document.getElementById('signTypedDataV4VerifyResult')
 
 const initialize = async () => {
+  try {
+    // We must specify the network as 'any' for ethers to allow network changes
+    ethersProvider = new ethers.providers.Web3Provider(window.ethereum, 'any')
+    hstFactory = new ethers.ContractFactory(
+      hstAbi,
+      hstBytecode,
+      ethersProvider.getSigner(),
+    )
+    piggybankFactory = new ethers.ContractFactory(
+      piggybankAbi,
+      piggybankBytecode,
+      ethersProvider.getSigner(),
+    )
+  } catch (error) {
+    console.error(error)
+  }
 
   let onboarding
   try {


### PR DESCRIPTION
With the migration to `ethers`, we accidentally broke onboarding. We had assumed that `window.ethereum` was always present.

The initialization steps that use `window.ethereum` have been moved into the `initialization` method, and wrapped in a `try..catch` to ensure te remainder of the intialization proceeds even if MetaMask is not installed.