### PR TITLE
Include sourcemaps in bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const CopyPlugin = require('copy-webpack-plugin')
 const DIST = path.resolve(__dirname, 'dist')
 
 module.exports = {
+  devtool: 'eval-source-map',
   mode: 'development',
   entry: './src/index.js',
   output: {


### PR DESCRIPTION
Sourcemaps are now generated by Webpack and included in the application bundle, both in development and production. This has dramatically increased the size of the bundle (~6x), but given that this dapp is used primarily for development, I think it's worth the cost.