### PR TITLE
Fix `remote` option of deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -59,12 +59,15 @@ function preprocess_and_publish {
   local shorthash
   shorthash=$(get_shorthash)
 
+  local remote_url
+  remote_url=$(git remote get-url "${GH_REMOTE}")
+
   cd ${WEBSITE_DIR_PATH} || abort "Failed to navigate to website directory"
 
   git init || abort "Failed to initialize git repository in website directory"
   git add -A . || abort "Failed to stage website files"
   git commit -m "update using ${SOURCE_BRANCH}/${shorthash}" || abort "Failed to commit website files"
-  git push -f git@github.com:MetaMask/test-dapp.git ${SOURCE_BRANCH}:${DEPLOY_BRANCH} || abort "Failed to push to ${GH_REMOTE}/${DEPLOY_BRANCH}"
+  git push -f "${remote_url}" ${SOURCE_BRANCH}:${DEPLOY_BRANCH} || abort "Failed to push to ${GH_REMOTE}/${DEPLOY_BRANCH}"
   echo "Successfully pushed to ${GH_REMOTE}/${DEPLOY_BRANCH}"
 
   rm -rf .git || abort "Failed to delete .git folder in ${WEBSITE_DIR_PATH}"


### PR DESCRIPTION
The `remote` option for the deploy script would not correctly set the remote used for deployment. It is used for everything but the most important step: the deploy step. For the `git push` that ultimately deploys the new build, the remote origin was hard-coded as the MetaMask test dapp repo.

A git command is now used to dynamically fetch the remote URL using the remote name given instead.