### PR TITLE
Replace 'master' references with 'main'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ static-server node_modules/@metamask/test-dapp/dist --port 9011
 
 ### Requires Manual Deployment
 
-After merging or pushing to `master`, please run `yarn deploy` in the package root directory if the contents of the `dist/` directory have changed.
+After merging or pushing to `main`, please run `yarn deploy` in the package root directory if the contents of the `dist/` directory have changed.
 
 ### Elements Must Be Selectable by XPath
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ readonly __SCRIPT_NAME__="${0##*/}"
 readonly __SEE_HELP_MESSAGE__="See '${__SCRIPT_NAME__} --help' for more information."
 
 GH_REMOTE='origin'
-SOURCE_BRANCH='master'
+SOURCE_BRANCH='main'
 DEPLOY_BRANCH='gh-pages'
 WEBSITE_DIR_PATH='dist'
 RETURN_PATH='..'
@@ -26,7 +26,7 @@ ${__SCRIPT_NAME__}
 Deploy site to GitHub Pages branch
 Options:
   -h, --help                    Show help text
-  -s, --source <branch>         Upstream branch (defaults to 'master')
+  -s, --source <branch>         Upstream branch (defaults to 'main')
   -d, --destination <branch>    Branch to deploy to (defaults to 'gh-pages')
   -r, --remote <remote>         Remote to deploy to (defaults to 'origin')
 EOF


### PR DESCRIPTION
Replaces references to `master` with `main` following default branch renaming.