### PR TITLE
Fix deploy script by parameterizing init branch

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -64,7 +64,7 @@ function preprocess_and_publish {
 
   cd ${WEBSITE_DIR_PATH} || abort "Failed to navigate to website directory"
 
-  git init || abort "Failed to initialize git repository in website directory"
+  git init -b ${SOURCE_BRANCH} || abort "Failed to initialize git repository in website directory"
   git add -A . || abort "Failed to stage website files"
   git commit -m "update using ${SOURCE_BRANCH}/${shorthash}" || abort "Failed to commit website files"
   git push -f "${remote_url}" ${SOURCE_BRANCH}:${DEPLOY_BRANCH} || abort "Failed to push to ${GH_REMOTE}/${DEPLOY_BRANCH}"


### PR DESCRIPTION
Our deploy script was relying on the author and the repo having the same default git branch name. This parameterizes the `git init` default branch in the deploy script to ensure that it works regardless of the repository's default branch name and the deployer's default branch name.