### PR TITLE
Add ability to dynamically set to: (address) and value: (in decimal) via query parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,20 @@
 import MetaMaskOnboarding from '@metamask/onboarding'
 // eslint-disable-next-line camelcase
 import { encrypt, recoverPersonalSignature, recoverTypedSignatureLegacy, recoverTypedSignature, recoverTypedSignature_v4 } from 'eth-sig-util'
-import { ethers } from 'ethers'
+import { ethers, utils } from 'ethers'
 import { toChecksumAddress } from 'ethereumjs-util'
 import { hstBytecode, hstAbi, piggybankBytecode, piggybankAbi } from './constants.json'
 
 let ethersProvider
 let hstFactory
 let piggybankFactory
+
+window.utils = utils
+
+const queryParams = new URLSearchParams(document.location.search.substring(1))
+const _val = queryParams.get('value')
+const _value = (_val && utils.parseEther(_val)._hex) || '0x29a2241af62c0000'
+const _to = queryParams.get('to') || '0x2f318C334780961FB129D2a6c30D0763d9a5C970'
 
 const currentUrl = new URL(window.location.href)
 const forwarderOrigin = currentUrl.hostname === 'localhost'
@@ -275,8 +282,8 @@ const initialize = async () => {
 
     sendButton.onclick = async () => {
       const result = await ethersProvider.getSigner().sendTransaction({
-        to: '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
-        value: '0x29a2241af62c0000',
+        to: _to,
+        value: _value,
         gasLimit: 21000,
         gasPrice: 20000000000,
       })


### PR DESCRIPTION
I usually just make these sort of changes locally and host there with something like `ngrok` so it will work in the mobile app, but I thought it might be nice to expose something like this in the hosted app and am curious what other people think.

reasoning:

the default send amount is `'0x29a2241af62c0000'` which is 3 ETH!:

![image](https://user-images.githubusercontent.com/675259/113796890-33467280-971e-11eb-9df2-3ca47657197c.png)

now i can just add `?value=0.001` to the URI and do a send with that amount instead:

![image](https://user-images.githubusercontent.com/675259/113796979-61c44d80-971e-11eb-9720-f690010f995d.png)

this also allows for specifying a different wallet address for the send since you might not want to send to `0x2f318C334780961FB129D2a6c30D0763d9a5C970` (seriously i have probably sent so much ETH to that address now).

I also expose some globals since it's nice to be able to do some conversions easily somewhere and the console on the test dapp seemed okay.

Eventually it might be nice to add some inputs so you can set the send to and value that way as well.

