### PR TITLE
make chainId string in one test for increased type coverage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -739,7 +739,7 @@ const initialize = async () => {
     const chainId = parseInt(chainIdDiv.innerHTML, 16) || networkId
     const msgParams = {
       domain: {
-        chainId,
+        chainId: chainId.toString(),
         name: 'Ether Mail',
         verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
         version: '1',


### PR DESCRIPTION
A simple change that expands coverage of types that chainID might be input as for signTypedMessage call, call with chainID as int remains covered by the  signTypedDataV3.onclick() method in tests. Would have prevented [this regression in 9.6.0](https://github.com/MetaMask/metamask-extension/issues/11308)