### PR TITLE
Send Tokens flow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -359,7 +359,7 @@ const initialize = async () => {
     createToken.onclick = async () => {
       const _initialAmount = 100;
       const _tokenName = 'TST';
-      const _decimalUnits = 0;
+      const _decimalUnits = 4;
       const _tokenSymbol = 'TST';
 
       try {


### PR DESCRIPTION
Explanation: Fixes an issue where the Send screen in MM would show 1500 TST instead of 1.5 TST after calling Watch Asset 

Manual testing steps:
1) Click Connect
2) Click Create Token in the Send Tokens section
3) Click Add Token to Wallet
4) Click Transfer Tokens
