### PR TITLE
Fixes signTypedData_v3 message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -740,11 +740,11 @@ const initialize = async () => {
         verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
       },
       message: {
-        sender: {
+        from: {
           name: 'Cow',
           wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
         },
-        recipient: {
+        to: {
           name: 'Bob',
           wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
         },
@@ -798,11 +798,11 @@ const initialize = async () => {
         verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
       },
       message: {
-        sender: {
+        from: {
           name: 'Cow',
           wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
         },
-        recipient: {
+        to: {
           name: 'Bob',
           wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
         },


### PR DESCRIPTION
The previous message was not compilant with EIP712 and was rejected by
the GridPlus Lattice. The `message` key names must map to the `Mail`
object definitions.