### PR TITLE
v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [5.0.0]
 ### Added
 - Add buttons to send transaction and deploy contract that will fail([#139](git+https://github.com/MetaMask/test-dapp/pull/139))
 - add deploy and mint buttons for collectibles flow ([#136](git+https://github.com/MetaMask/test-dapp/pull/136))
@@ -22,4 +24,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](git+https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](git+https://github.com/MetaMask/test-dapp/pull/93))
 
-[Unreleased]: git+https://github.com/MetaMask/test-dapp/
+[Unreleased]: git+https://github.com/MetaMask/test-dapp/compare/v5.0.0...HEAD
+[5.0.0]: git+https://github.com/MetaMask/test-dapp/releases/tag/v5.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 12.0.0"


### PR DESCRIPTION
## [5.0.0]
### Added
- Add buttons to send transaction and deploy contract that will fail([#139](git+https://github.com/MetaMask/test-dapp/pull/139))
- add deploy and mint buttons for collectibles flow ([#136](git+https://github.com/MetaMask/test-dapp/pull/136))
- Add warning when using Test Dapp on Mainnet ([#134](git+https://github.com/MetaMask/test-dapp/pull/134))
- Add form to send transaction with parameters([#132](git+https://github.com/MetaMask/test-dapp/pull/132))
- Add button to send EIP1559 transaction ([#117](git+https://github.com/MetaMask/test-dapp/pull/117))
- Add button to suggest switching Ethereum chains([#102](git+https://github.com/MetaMask/test-dapp/pull/102))
- Add button to call watch-asset ([#112](git+https://github.com/MetaMask/test-dapp/pull/112))
- Add button to suggest adding Ethereum chain ([#92](git+https://github.com/MetaMask/test-dapp/pull/92))

### Fixed
- Remove known hacked address from send flow. ([#129](git+https://github.com/MetaMask/test-dapp/pull/129))
- Fix decimal unit error in send token flow ([#131](git+https://github.com/MetaMask/test-dapp/pull/131))
- Fix signTypedData_v3 message ([#133](git+https://github.com/MetaMask/test-dapp/pull/133))
- Fix repository standardization issues ([#118](git+https://github.com/MetaMask/test-dapp/pull/118))
- Fix addEthereumChain button disable logic ([#93](git+https://github.com/MetaMask/test-dapp/pull/93))