### PR TITLE
Fix event used for accessing provider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1271,7 +1271,7 @@ const initialize = async () => {
   }
 };
 
-window.addEventListener('DOMContentLoaded', initialize);
+window.addEventListener('load', initialize);
 
 // utils
 


### PR DESCRIPTION
Using load event ensures that `window.ethereum` is always available in global scope when we access provider.