### PR TITLE
Update xDAI information to Gnosis Chain

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -580,14 +580,14 @@
                   id="addEthereumChain"
                   disabled
                 >
-                  Add xDAI Chain
+                  Add Gnosis Chain
                 </button>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="switchEthereumChain"
                   disabled
                 >
-                  Switch to xDAI Chain
+                  Switch to Gnosis Chain
                 </button>
               </div>
             </div>

--- a/src/index.js
+++ b/src/index.js
@@ -289,10 +289,10 @@ const initialize = async () => {
       params: [
         {
           chainId: '0x64',
-          rpcUrls: ['https://dai.poa.network'],
-          chainName: 'xDAI Chain',
+          rpcUrls: ['https://rpc.gnosischain.com'],
+          chainName: 'Gnosis Chain',
           nativeCurrency: { name: 'xDAI', decimals: 18, symbol: 'xDAI' },
-          blockExplorerUrls: ['https://blockscout.com/poa/xdai'],
+          blockExplorerUrls: ['https://blockscout.com/xdai/mainnet'],
         },
       ],
     });


### PR DESCRIPTION
`https://dai.poa.network` seems dead, this PR updates all the xDAI Chain data to the latest Gnosis Chain data.