### PR TITLE
Contract already deployed

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -159,7 +159,7 @@
                 </button>
                 <hr />
                 <h4 class="card-title">
-                  Contract
+                  Piggy bank contract
                 </h4>
 
                 <button


### PR DESCRIPTION
**Explanation:**

Fixes: https://github.com/MetaMask/test-dapp/issues/160

Updates the test dapp to consume a query string parameter that describes a deployed contracts address, such as `http://localhost:9011/?contract=0x7F775B6392f46Cf717aBB204557f64F68eB388c1`

This change will allow us to;
- avoid repeatedly deploying a contract when testing (manual testing)
- deploy a contract in the test setup instead of via the browser in the test steps (e2e tests)

**More information:**
- The contract address in the query string param will be applied to all contracts
- You can override the contract address for a specific contract by deploying it

**Before:**

After refreshing the page, there's no way to interact with the deployed contract

https://user-images.githubusercontent.com/53189696/175405985-4c510f99-0f6a-4acf-91b5-700ca6c024f2.mov

**After:**

Once you add the query string param, you can interact with a deployed contract

https://user-images.githubusercontent.com/53189696/175406016-bc77ff0d-e417-42b9-99e4-9e5e41e2e63a.mov

**Manual testing steps:**
- Without query string param: Test deploying and interacting with all contracts
- With query string param: Test interacting with all contracts

