### PR TITLE
v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0]
+### Added
+- Add a Sign In With Ethereum (SIWE) section to test signing messages that conform to [EIP-4361 spec](https://eips.ethereum.org/EIPS/eip-4361) ([#164](https://github.com/MetaMask/test-dapp/pull/164))
+
 ## [5.2.1]
 ### Added
 - Add button to revoke NFT allowances ([#187](git+https://github.com/MetaMask/test-dapp/pull/187))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 12.0.0"


### PR DESCRIPTION
## [5.3.0]
### Added
- Add a Sign In With Ethereum (SIWE) section to test signing messages that conform to [EIP-4361 spec](https://eips.ethereum.org/EIPS/eip-4361) ([#164](https://github.com/MetaMask/test-dapp/pull/164))