### PR TITLE
Set approval for all erc1155

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -486,6 +486,26 @@
               </button>
             </div>
 
+            <div class="form-group">
+              <button
+                class="btn btn-primary btn-lg btn-block mb-3"
+                id="setApprovalForAllERC1155Button"
+                disabled
+              >
+                Set Approval For All
+              </button>
+            </div>
+
+            <div class="form-group">
+              <button
+                class="btn btn-primary btn-lg btn-block mb-3"
+                id="revokeERC1155Button"
+                disabled
+              >
+                Revoke
+              </button>
+            </div>
+
             <p class="info-text alert alert-secondary">
               ERC 1155: <span id="erc1155Status"></span>
             </p>

--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,10 @@ const batchTransferTokenAmounts = document.getElementById(
 const batchTransferFromButton = document.getElementById(
   'batchTransferFromButton',
 );
+const setApprovalForAllERC1155Button = document.getElementById(
+  'setApprovalForAllERC1155Button',
+);
+const revokeERC1155Button = document.getElementById('revokeERC1155Button');
 const erc1155Status = document.getElementById('erc1155Status');
 
 // Send Eth Section
@@ -289,6 +293,8 @@ const initialize = async () => {
     batchTransferTokenIds,
     batchTransferTokenAmounts,
     batchTransferFromButton,
+    setApprovalForAllERC1155Button,
+    revokeERC1155Button,
     deployFailingButton,
     sendFailingButton,
     deployMultisigButton,
@@ -429,6 +435,8 @@ const initialize = async () => {
       batchTransferTokenIds.disabled = false;
       batchTransferTokenAmounts.disabled = false;
       batchTransferFromButton.disabled = false;
+      setApprovalForAllERC1155Button.disabled = false;
+      revokeERC1155Button.disabled = false;
       // ERC20 Token - Send Tokens
       tokenAddress.innerHTML = hstContract.address;
       watchAsset.disabled = false;
@@ -750,6 +758,8 @@ const initialize = async () => {
       batchTransferTokenAmounts.disabled = false;
       batchMintButton.disabled = false;
       batchTransferFromButton.disabled = false;
+      setApprovalForAllERC1155Button.disabled = false;
+      revokeERC1155Button.disabled = false;
     };
 
     batchMintButton.onclick = async () => {
@@ -796,6 +806,34 @@ const initialize = async () => {
       }
       console.log(result);
       erc1155Status.innerHTML = 'Batch Transfer From completed';
+    };
+
+    setApprovalForAllERC1155Button.onclick = async () => {
+      erc1155Status.innerHTML = 'Set Approval For All initiated';
+      let result = await erc1155Contract.setApprovalForAll(
+        '0x9bc5baF874d2DA8D216aE9f137804184EE5AfEF4',
+        true,
+        {
+          from: accounts[0],
+        },
+      );
+      result = await result.wait();
+      console.log(result);
+      erc1155Status.innerHTML = 'Set Approval For All completed';
+    };
+
+    revokeERC1155Button.onclick = async () => {
+      erc1155Status.innerHTML = 'Revoke initiated';
+      let result = await erc1155Contract.setApprovalForAll(
+        '0x9bc5baF874d2DA8D216aE9f137804184EE5AfEF4',
+        false,
+        {
+          from: accounts[0],
+        },
+      );
+      result = await result.wait();
+      console.log(result);
+      erc1155Status.innerHTML = 'Revoke completed';
     };
 
     /**


### PR DESCRIPTION
Add the following methods:

- setApprovalForAll (sets/unset the approval for an address to transfer all NFTs)

Test Dapp (Add Set Approval For All & Revoke button to the ERC 1155 section)
<img width="1511" alt="test-dapp-erc1155-setApprovalForAll" src="https://user-images.githubusercontent.com/53189696/221928743-36c435b0-c074-4f5b-9d6b-bc8f6cab6c72.png">

setApprovalForAll - true
<img width="472" alt="erc1155-setApprovalForAll 1" src="https://user-images.githubusercontent.com/53189696/221928861-1ef08bd0-2f44-4b5f-b267-8f029ccbcb88.png">

setApprovalForAll - false
<img width="472" alt="erc1155-setApprovalForAll 2" src="https://user-images.githubusercontent.com/53189696/221929019-f9db67fe-bbcb-4cf7-8be9-a7915e666f2c.png">
