### PR TITLE
Introducing Permit Signature

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -737,6 +737,46 @@
             <div class="card full-width">
               <div class="card-body">
                 <h4>
+                  Sign Permit
+                </h4>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signPermit"
+                  disabled
+                >
+                  Sign
+                </button>
+
+                <p class="info-text alert alert-warning">
+                  Result:
+                  <span id="signPermitResult"></span>
+                  <p class="info-text alert alert-warning" id="signPermitResultR">r: </p>
+                  <p class="info-text alert alert-warning" id="signPermitResultS">s: </p>
+                  <p class="info-text alert alert-warning" id="signPermitResultV">v: </p>
+                </p>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signPermitVerify"
+                  disabled
+                >
+                  Verify
+                </button>
+
+                <p class="info-text alert alert-warning">
+                  Recovery result:
+                  <span id="signPermitVerifyResult"></span>
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="col-xl-4 col-lg-6 col-md-12 col-sm-12 col-12 d-flex align-items-stretch"
+          >
+            <div class="card full-width">
+              <div class="card-body">
+                <h4>
                   Sign In With Ethereum
                 </h4>
 

--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,15 @@ const signTypedDataV4Verify = document.getElementById('signTypedDataV4Verify');
 const signTypedDataV4VerifyResult = document.getElementById(
   'signTypedDataV4VerifyResult',
 );
+const signPermit = document.getElementById('signPermit');
+const signPermitResult = document.getElementById('signPermitResult');
+const signPermitResultR = document.getElementById('signPermitResultR');
+const signPermitResultS = document.getElementById('signPermitResultS');
+const signPermitResultV = document.getElementById('signPermitResultV');
+const signPermitVerify = document.getElementById('signPermitVerify');
+const signPermitVerifyResult = document.getElementById(
+  'signPermitVerifyResult',
+);
 const siwe = document.getElementById('siwe');
 const siweResources = document.getElementById('siweResources');
 const siweBadDomain = document.getElementById('siweBadDomain');
@@ -313,6 +322,8 @@ const initialize = async () => {
     signTypedDataV3Verify,
     signTypedDataV4,
     signTypedDataV4Verify,
+    signPermit,
+    signPermitVerify,
     siwe,
     siweResources,
     siweBadDomain,
@@ -372,6 +383,7 @@ const initialize = async () => {
       signTypedData.disabled = false;
       signTypedDataV3.disabled = false;
       signTypedDataV4.disabled = false;
+      signPermit.disabled = false;
       siwe.disabled = false;
       siweResources.disabled = false;
       siweBadDomain.disabled = false;
@@ -1569,6 +1581,159 @@ const initialize = async () => {
     } catch (err) {
       console.error(err);
       signTypedDataV4VerifyResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  /**
+   *  Sign Permit
+   */
+  signPermit.onclick = async () => {
+    const networkId = parseInt(networkDiv.innerHTML, 10);
+    const chainId = parseInt(chainIdDiv.innerHTML, 16) || networkId;
+    const from = accounts[0];
+
+    const domain = {
+      name: 'MyToken',
+      version: '1',
+      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+      chainId,
+    };
+
+    const EIP712Domain = [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'chainId', type: 'uint256' },
+    ];
+
+    const permit = {
+      owner: from,
+      spender: '0x5B38Da6a701c568545dCfcB03FcB875f56beddC4',
+      value: 3000,
+      nonce: 0,
+      deadline: 50000000000,
+    };
+
+    const Permit = [
+      { name: 'owner', type: 'address' },
+      { name: 'spender', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'nonce', type: 'uint256' },
+      { name: 'deadline', type: 'uint256' },
+    ];
+
+    const splitSig = (sig) => {
+      const pureSig = sig.replace('0x', '');
+
+      const _r = Buffer.from(pureSig.substring(0, 64), 'hex');
+      const _s = Buffer.from(pureSig.substring(64, 128), 'hex');
+      const _v = Buffer.from(
+        parseInt(pureSig.substring(128, 130), 16).toString(),
+      );
+
+      return { _r, _s, _v };
+    };
+
+    let sign;
+    let r;
+    let s;
+    let v;
+
+    const msgParams = {
+      types: {
+        EIP712Domain,
+        Permit,
+      },
+      primaryType: 'Permit',
+      domain,
+      message: permit,
+    };
+
+    try {
+      sign = await ethereum.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+      const { _r, _s, _v } = splitSig(sign);
+      r = `0x${_r.toString('hex')}`;
+      s = `0x${_s.toString('hex')}`;
+      v = _v.toString();
+
+      signPermitResult.innerHTML = sign;
+      signPermitResultR.innerHTML = `r: ${r}`;
+      signPermitResultS.innerHTML = `s: ${s}`;
+      signPermitResultV.innerHTML = `v: ${v}`;
+      signPermitVerify.disabled = false;
+    } catch (err) {
+      console.error(err);
+      signPermitResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  /**
+   *  Sign Permit Verification
+   */
+  signPermitVerify.onclick = async () => {
+    const networkId = parseInt(networkDiv.innerHTML, 10);
+    const chainId = parseInt(chainIdDiv.innerHTML, 16) || networkId;
+    const from = accounts[0];
+
+    const domain = {
+      name: 'MyToken',
+      version: '1',
+      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+      chainId,
+    };
+
+    const EIP712Domain = [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'chainId', type: 'uint256' },
+    ];
+
+    const permit = {
+      owner: from,
+      spender: '0x5B38Da6a701c568545dCfcB03FcB875f56beddC4',
+      value: 3000,
+      nonce: 0,
+      deadline: 50000000000,
+    };
+
+    const Permit = [
+      { name: 'owner', type: 'address' },
+      { name: 'spender', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'nonce', type: 'uint256' },
+      { name: 'deadline', type: 'uint256' },
+    ];
+
+    const msgParams = {
+      types: {
+        EIP712Domain,
+        Permit,
+      },
+      primaryType: 'Permit',
+      domain,
+      message: permit,
+    };
+    try {
+      const sign = signPermitResult.innerHTML;
+      const recoveredAddr = recoverTypedSignatureV4({
+        data: msgParams,
+        sig: sign,
+      });
+      if (toChecksumAddress(recoveredAddr) === toChecksumAddress(from)) {
+        console.log(`Successfully verified signer as ${recoveredAddr}`);
+        signPermitVerifyResult.innerHTML = recoveredAddr;
+      } else {
+        console.log(
+          `Failed to verify signer when comparing ${recoveredAddr} to ${from}`,
+        );
+      }
+    } catch (err) {
+      console.error(err);
+      signPermitVerifyResult.innerHTML = `Error: ${err.message}`;
     }
   };
 


### PR DESCRIPTION
**What**: in this PR we are introducing a specific Typed Data V4 signature: Permit. According to the [specs for EIP-2612,](https://eips.ethereum.org/EIPS/eip-2612) the signature will have a data type `Permit` with the following data fields:

```
  "message": {
    "owner": owner,
    "spender": spender,
    "value": value,
    "nonce": nonce,
    "deadline": deadline
  }
```

https://user-images.githubusercontent.com/54408225/222073236-79861434-79e9-4a42-8587-1559f4ee5d2f.mp4

- Fixes https://github.com/MetaMask/metamask-extension/issues/17941

**How**: 
- the first part of the work, and the scope of this PR, consists in introducing a Permit signature.
- a future PR will take care of importing an ERC20 Permit contract which implements the permit signature, and complete the flow by adding the functionality of executing the Permit and seeing how allowance is increased only by signing a Permit signature.
- the signature split of v, r and s fields in this PR is a preparatory work, that would be needed for the future PR

