### PR TITLE
Adding an input for ERC20 token decimals

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -256,6 +256,18 @@
                   Token: <span id="tokenAddress"></span>
                 </p>
 
+                <div class="form-group">
+                  <label>Token Decimals</label>
+                  <input
+                    class="form-control"
+                    type="number"
+                    id="tokenDecimals"
+                    value="4"
+                    max="18"
+                    min="0"
+                  />
+                </div>
+
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="createToken"

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ const sendButton = document.getElementById('sendButton');
 const sendEIP1559Button = document.getElementById('sendEIP1559Button');
 
 // Send Tokens Section
-const decimalUnits = 4;
+const decimalUnitsInput = document.getElementById('tokenDecimals');
 const tokenSymbol = 'TST';
 const tokenAddress = document.getElementById('tokenAddress');
 const createToken = document.getElementById('createToken');
@@ -310,6 +310,7 @@ const initialize = async () => {
     sendMultisigButton,
     sendButton,
     createToken,
+    decimalUnitsInput,
     watchAsset,
     transferTokens,
     approveTokens,
@@ -381,6 +382,7 @@ const initialize = async () => {
       deployFailingButton.disabled = false;
       deployMultisigButton.disabled = false;
       createToken.disabled = false;
+      decimalUnitsInput.disabled = false;
       personalSign.disabled = false;
       signTypedData.disabled = false;
       getEncryptionKeyButton.disabled = false;
@@ -898,7 +900,7 @@ const initialize = async () => {
         hstContract = await hstFactory.deploy(
           _initialAmount,
           _tokenName,
-          decimalUnits,
+          decimalUnitsInput.value,
           tokenSymbol,
         );
         await hstContract.deployTransaction.wait();
@@ -930,7 +932,7 @@ const initialize = async () => {
           options: {
             address: hstContract.address,
             symbol: tokenSymbol,
-            decimals: decimalUnits,
+            decimals: decimalUnitsInput.value,
             image: 'https://metamask.github.io/test-dapp/metamask-fox.svg',
           },
         },


### PR DESCRIPTION
**Context**: several issues have been reported related to sending ERC20 tokens with 0 decimals or certain value of decimals.
- https://github.com/MetaMask/metamask-extension/issues/17839
- https://github.com/MetaMask/metamask-extension/issues/18139

**What**: this PR adds the ability to input the desired amount of decimals for the ERC20 token (between 0 and 18). This way we will be able to manually test ERC20 tokens with certain problematic decimal values, like 0.

![image](https://user-images.githubusercontent.com/54408225/225290457-6e8b90ad-afda-495d-8208-6983458b2359.png)



**How**:
- It has been observed that, that we used to pass a value `4` for the decimals in the contract constructor. However this value does not really have an effect on the token contract - it's always 4 decimals, no matter if we change it to another value. This means that the contract must have hard-coded this value (unfortunately we don't have the code for this contract). For this reason, we will need to update the ERC20 Contract, in order to make effective the value passed on the constructor. This is done in a [separate PR.](https://github.com/MetaMask/test-dapp/pull/220)

https://user-images.githubusercontent.com/54408225/225268036-6044818a-9821-4c26-b685-0be97e6cf264.mp4

- For not impacting on any of the existing tests relying on the previous value of 4 decimals, the default value will be set to 4.

