### PR TITLE
Support URL parameter to scroll to element on load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ const forwarderOrigin =
   currentUrl.hostname === 'localhost' ? 'http://localhost:9010' : undefined;
 const urlSearchParams = new URLSearchParams(window.location.search);
 const deployedContractAddress = urlSearchParams.get('contract');
+const scrollTo = urlSearchParams.get('scrollTo');
 
 const { isMetaMaskInstalled } = MetaMaskOnboarding;
 
@@ -291,6 +292,7 @@ const initialize = async () => {
 
   let accounts;
   let accountButtonsInitialized = false;
+  let scrollToHandled = false;
 
   const accountButtons = [
     deployButton,
@@ -1840,6 +1842,12 @@ const initialize = async () => {
     } else {
       warningDiv.classList.add('warning-invisible');
     }
+
+    // Wait until warning rendered or not to improve accuracy 
+    if (!scrollToHandled) {
+      scrollToHandled = true;
+      setTimeout(handleScrollTo, 1000);
+    }
   }
 
   function handleEIP1559Support(supported) {
@@ -1856,6 +1864,23 @@ const initialize = async () => {
 
   function handleNewNetwork(networkId) {
     networkDiv.innerHTML = networkId;
+  }
+
+  function handleScrollTo() {
+    if (!scrollTo) return;
+
+    scrollToHandled = true;
+
+    console.log('Attempting to scroll to element with ID:', scrollTo);
+
+    const scrollToElement = document.getElementById(scrollTo);
+
+    if (!scrollToElement) {
+      console.log('Cannot find element with ID:', scrollTo);
+      return;
+    }
+
+    scrollToElement.scrollIntoView();
   }
 
   async function getNetworkAndChainId() {
@@ -1922,6 +1947,8 @@ const initialize = async () => {
     } catch (err) {
       console.error('Error on init when getting accounts', err);
     }
+  } else {
+    handleScrollTo();
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1843,7 +1843,7 @@ const initialize = async () => {
       warningDiv.classList.add('warning-invisible');
     }
 
-    // Wait until warning rendered or not to improve accuracy 
+    // Wait until warning rendered or not to improve accuracy
     if (!scrollToHandled) {
       scrollToHandled = true;
       setTimeout(handleScrollTo, 1000);
@@ -1867,7 +1867,9 @@ const initialize = async () => {
   }
 
   function handleScrollTo() {
-    if (!scrollTo) return;
+    if (!scrollTo) {
+      return;
+    }
 
     scrollToHandled = true;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1845,8 +1845,7 @@ const initialize = async () => {
 
     // Wait until warning rendered or not to improve accuracy
     if (!scrollToHandled) {
-      scrollToHandled = true;
-      setTimeout(handleScrollTo, 1000);
+      handleScrollTo({ delay: true });
     }
   }
 
@@ -1866,7 +1865,7 @@ const initialize = async () => {
     networkDiv.innerHTML = networkId;
   }
 
-  function handleScrollTo() {
+  async function handleScrollTo({ delay = false } = {}) {
     if (!scrollTo) {
       return;
     }
@@ -1878,8 +1877,12 @@ const initialize = async () => {
     const scrollToElement = document.getElementById(scrollTo);
 
     if (!scrollToElement) {
-      console.log('Cannot find element with ID:', scrollTo);
+      console.warn('Cannot find element with ID:', scrollTo);
       return;
+    }
+
+    if (delay) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
     }
 
     scrollToElement.scrollIntoView();


### PR DESCRIPTION
Support the `scrollTo` URL parameter to automatically scroll to an element ID after loading the page.

Required to support E2E tests in mobile as the testing framework (Detox) does not yet support direct interaction with the browser in iOS.