### PR TITLE
Fix NFT tokenId type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -700,7 +700,7 @@ const initialize = async () => {
                   type: 'ERC721',
                   options: {
                     address: nftsContractAddress,
-                    tokenId,
+                    tokenId: tokenId.toString(),
                   },
                 },
               };
@@ -744,7 +744,7 @@ const initialize = async () => {
                 type: 'ERC721',
                 options: {
                   address: nftsContractAddress,
-                  tokenId: i + 1,
+                  tokenId: `${i + 1}`,
                 },
               },
             });


### PR DESCRIPTION
`tokenId` param for `wallet_watchAsset` should be type 'string'. 

Related issue: https://github.com/MetaMask/MetaMask-planning/issues/853
Related PR: https://github.com/MetaMask/metamask-extension/pull/19738