### PR TITLE
Watch NFT by id instead of generating a watch NFT button for each token id

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -356,6 +356,26 @@
                 </div>
 
                 <div class="form-group">
+                  <label>Watch NFT</label>
+                  <input
+                    class="form-control"
+                    type="number"
+                    id="watchNFTInput"
+                    value="1"
+                  />
+                </div>
+
+                <div class="form-group">
+                  <button
+                    class="btn btn-primary btn-lg btn-block mb-3"
+                    id="watchNFTButton"
+                    disabled
+                  >
+                    Watch NFT
+                  </button>
+                </div>
+
+                <div class="form-group">
                   <button
                     class="btn btn-primary btn-lg btn-block mb-3"
                     id="watchNFTsButton"

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,8 @@ const watchNFTButtons = document.getElementById('watchNFTButtons');
 const mintAmountInput = document.getElementById('mintAmountInput');
 const approveTokenInput = document.getElementById('approveTokenInput');
 const approveButton = document.getElementById('approveButton');
+const watchNFTInput = document.getElementById('watchNFTInput');;
+const watchNFTButton = document.getElementById('watchNFTButton');;
 const setApprovalForAllButton = document.getElementById(
   'setApprovalForAllButton',
 );
@@ -304,6 +306,8 @@ const initialize = async () => {
     mintAmountInput,
     approveTokenInput,
     approveButton,
+    watchNFTInput,
+    watchNFTButton,
     setApprovalForAllButton,
     revokeButton,
     transferTokenInput,
@@ -452,6 +456,8 @@ const initialize = async () => {
       mintAmountInput.disabled = false;
       approveTokenInput.disabled = false;
       approveButton.disabled = false;
+      watchNFTInput.disabled = false;
+      watchNFTButton.disabled = false
       setApprovalForAllButton.disabled = false;
       revokeButton.disabled = false;
       transferTokenInput.disabled = false;
@@ -723,38 +729,33 @@ const initialize = async () => {
       nftsStatus.innerHTML = 'Mint completed';
       approveTokenInput.disabled = false;
       approveButton.disabled = false;
+      watchNFTInput.disabled = false;
+      watchNFTButton.disabled = false;
       setApprovalForAllButton.disabled = false;
       revokeButton.disabled = false;
       transferTokenInput.disabled = false;
       transferFromButton.disabled = false;
       watchNFTsButton.disabled = false;
       watchNFTButtons.innerHTML = '';
-      const nftsContractAddress = nftsContract.address;
-      const currentTokenId = await nftsContract.currentTokenId();
-      for (let i = 0; i < currentTokenId; i++) {
-        const button = document.createElement('button');
-        button.innerHTML = `Watch NFT ${i + 1}`;
-        button.className = 'btn btn-primary btn-lg btn-block mb-3';
-        button.onclick = async () => {
-          let watchNftsResult;
-          try {
-            watchNftsResult = await ethereum.request({
-              method: 'wallet_watchAsset',
-              params: {
-                type: 'ERC721',
-                options: {
-                  address: nftsContractAddress,
-                  tokenId: `${i + 1}`,
-                },
-              },
-            });
-          } catch (error) {
-            console.error(error);
-          }
-          console.log(watchNftsResult);
-        };
-        watchNFTButtons.appendChild(button);
+    };
+
+    watchNFTButton.onclick = async () => {
+      let watchNftsResult;
+      try {
+        watchNftsResult = await ethereum.request({
+          method: 'wallet_watchAsset',
+          params: {
+            type: 'ERC721',
+            options: {
+              address: nftsContract.address,
+              tokenId: watchNFTInput.value,
+            },
+          },
+        });
+      } catch (error) {
+        console.error(error);
       }
+      console.log(watchNftsResult);
     };
 
     approveButton.onclick = async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -86,8 +86,8 @@ const watchNFTButtons = document.getElementById('watchNFTButtons');
 const mintAmountInput = document.getElementById('mintAmountInput');
 const approveTokenInput = document.getElementById('approveTokenInput');
 const approveButton = document.getElementById('approveButton');
-const watchNFTInput = document.getElementById('watchNFTInput');;
-const watchNFTButton = document.getElementById('watchNFTButton');;
+const watchNFTInput = document.getElementById('watchNFTInput');
+const watchNFTButton = document.getElementById('watchNFTButton');
 const setApprovalForAllButton = document.getElementById(
   'setApprovalForAllButton',
 );
@@ -457,7 +457,7 @@ const initialize = async () => {
       approveTokenInput.disabled = false;
       approveButton.disabled = false;
       watchNFTInput.disabled = false;
-      watchNFTButton.disabled = false
+      watchNFTButton.disabled = false;
       setApprovalForAllButton.disabled = false;
       revokeButton.disabled = false;
       transferTokenInput.disabled = false;


### PR DESCRIPTION
# Context
After the Watch NFT function has been added, we can see how button elements are created whenever we mint NFTs. I.e. minting 30 NFTs would correspond to create 30 watch NFT buttons.
This can be inefficient in terms of UI.

With this PR, we can watch the NFT by its id (instead of generating the long list of buttons).


## Before
If you minted 30 NFTs, you would get 30 buttons, for watching each individual asset.

![Screenshot from 2023-07-25 11-17-01](https://github.com/MetaMask/test-dapp/assets/54408225/98228533-dedd-4963-9618-09e4bbaba547)


## After
You can Watch the NFT by inputting its id, instead of getting a long list of buttons (corresponding to each id)

![Screenshot from 2023-07-25 11-33-04](https://github.com/MetaMask/test-dapp/assets/54408225/da193ddb-0a83-4347-b8b1-4c2dc2892b2b)

