### PR TITLE
Fix Network ID incorrectly using chainId value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2093,21 +2093,9 @@ const initialize = async () => {
     ethereum.autoRefreshOnNetworkChange = false;
     getNetworkAndChainId();
 
-    ethereum.autoRefreshOnNetworkChange = false;
-    getNetworkAndChainId();
-
-    ethereum.on('chainChanged', (chain) => {
-      handleNewChain(chain);
-      ethereum
-        .request({
-          method: 'eth_getBlockByNumber',
-          params: ['latest', false],
-        })
-        .then((block) => {
-          handleEIP1559Support(block.baseFeePerGas !== undefined);
-        });
-    });
-    ethereum.on('chainChanged', handleNewNetwork);
+    ethereum.on('chainChanged', () => getNetworkAndChainId());
+    // networkChanged is deprecated, but there is no other way to ensure we catch every network ID change
+    ethereum.on('networkChanged', () => getNetworkAndChainId());
     ethereum.on('accountsChanged', (newAccounts) => {
       ethereum
         .request({


### PR DESCRIPTION
Previously, the `chainChanged` event was being used as the network ID value. This is incorrect, as chain ID and network ID values may not match and are not guaranteed to be interchangeable. This PR fixes this issue by:
* using the `chainChanged` event to update both chainId and networkId 
* listening to the `networkChanged` event to update both chainId and networkId
  *  note that `networkChanged` is deprecated, but there is no other way to **guarantee** we don't miss a network ID change