### PR TITLE
feat: Add PPOM setApprovalForAll button. Add token symbols for PPOM buttons

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -640,10 +640,24 @@
                 </button>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
+                  id="maliciousERC721Transfer"
+                  disabled
+                >
+                  Malicious ERC721 Transfer
+                </button>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
                   id="maliciousApprovalButton"
                   disabled
                 >
                   Malicious ERC20 Approval
+                </button>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="maliciousSetApprovalForAll"
+                  disabled
+                >
+                  Malicious Set Approval For All
                 </button>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"

--- a/src/index.html
+++ b/src/index.html
@@ -636,14 +636,14 @@
                   id="maliciousERC20TransferButton"
                   disabled
                 >
-                  Malicious ERC20 Transfer
+                  Malicious ERC20 Transfer (USDC)
                 </button>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="maliciousApprovalButton"
                   disabled
                 >
-                  Malicious ERC20 Approval
+                  Malicious ERC20 Approval (BUSD)
                 </button>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"

--- a/src/index.html
+++ b/src/index.html
@@ -640,13 +640,6 @@
                 </button>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
-                  id="maliciousERC721Transfer"
-                  disabled
-                >
-                  Malicious ERC721 Transfer
-                </button>
-                <button
-                  class="btn btn-primary btn-lg btn-block mb-3"
                   id="maliciousApprovalButton"
                   disabled
                 >

--- a/src/index.js
+++ b/src/index.js
@@ -226,13 +226,17 @@ const maliciousApprovalButton = document.getElementById(
 );
 const maliciousERC20TransferButton = document.getElementById(
   'maliciousERC20TransferButton',
-  );
-const maliciousERC721Transfer = document.getElementById('maliciousERC721Transfer');
+);
+const maliciousERC721Transfer = document.getElementById(
+  'maliciousERC721Transfer',
+);
 const maliciousRawEthButton = document.getElementById('maliciousRawEthButton');
 const maliciousPermit = document.getElementById('maliciousPermit');
 const maliciousTradeOrder = document.getElementById('maliciousTradeOrder');
 const maliciousSeaport = document.getElementById('maliciousSeaport');
-const maliciousSetApprovalForAll = document.getElementById('maliciousSetApprovalForAll');
+const maliciousSetApprovalForAll = document.getElementById(
+  'maliciousSetApprovalForAll',
+);
 
 const initialize = async () => {
   try {
@@ -1032,8 +1036,8 @@ const initialize = async () => {
             to: '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
             gas: '0x30d40',
             gasPrice: '0x76c3b0342',
-            data: '0x8b72a2ec000000000000000000000000b85492afc686d5ca405e3cd4f50b05d358c75ede0000000000000000000000000000000000000000000000000000000000000001'
-          }
+            data: '0x8b72a2ec000000000000000000000000b85492afc686d5ca405e3cd4f50b05d358c75ede0000000000000000000000000000000000000000000000000000000000000001',
+          },
         ],
       });
       console.log(result);
@@ -1098,8 +1102,8 @@ const initialize = async () => {
           {
             from: accounts[0],
             to: '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d',
-            data: '0xa22cb465000000000000000000000000b85492afc686d5ca405e3cd4f50b05d358c75ede0000000000000000000000000000000000000000000000000000000000000001'
-          }
+            data: '0xa22cb465000000000000000000000000b85492afc686d5ca405e3cd4f50b05d358c75ede0000000000000000000000000000000000000000000000000000000000000001',
+          },
         ],
       });
       console.log(result);

--- a/src/index.js
+++ b/src/index.js
@@ -226,11 +226,13 @@ const maliciousApprovalButton = document.getElementById(
 );
 const maliciousERC20TransferButton = document.getElementById(
   'maliciousERC20TransferButton',
-);
+  );
+const maliciousERC721Transfer = document.getElementById('maliciousERC721Transfer');
 const maliciousRawEthButton = document.getElementById('maliciousRawEthButton');
 const maliciousPermit = document.getElementById('maliciousPermit');
 const maliciousTradeOrder = document.getElementById('maliciousTradeOrder');
 const maliciousSeaport = document.getElementById('maliciousSeaport');
+const maliciousSetApprovalForAll = document.getElementById('maliciousSetApprovalForAll');
 
 const initialize = async () => {
   try {
@@ -369,7 +371,9 @@ const initialize = async () => {
     siweMalformed,
     eip747WatchButton,
     maliciousApprovalButton,
+    maliciousSetApprovalForAll,
     maliciousERC20TransferButton,
+    maliciousERC721Transfer,
     maliciousRawEthButton,
     maliciousPermit,
     maliciousTradeOrder,
@@ -440,10 +444,12 @@ const initialize = async () => {
       eip747WatchButton.disabled = false;
       maliciousApprovalButton.disabled = false;
       maliciousERC20TransferButton.disabled = false;
+      maliciousERC721Transfer.disabled = false;
       maliciousRawEthButton.disabled = false;
       maliciousPermit.disabled = false;
       maliciousTradeOrder.disabled = false;
       maliciousSeaport.disabled = false;
+      maliciousSetApprovalForAll.disabled = false;
     }
 
     if (isMetaMaskInstalled()) {
@@ -1016,7 +1022,24 @@ const initialize = async () => {
       console.log(result);
     };
 
-    // Malicious raw ETH transfer
+    // Malicious ERC721 Transfer
+    maliciousERC721Transfer.onclick = async () => {
+      const result = await ethereum.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from: accounts[0],
+            to: '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
+            gas: '0x30d40',
+            gasPrice: '0x76c3b0342',
+            data: '0x8b72a2ec000000000000000000000000b85492afc686d5ca405e3cd4f50b05d358c75ede0000000000000000000000000000000000000000000000000000000000000001'
+          }
+        ],
+      });
+      console.log(result);
+    };
+
+    // // Malicious raw ETH transfer
     maliciousRawEthButton.onclick = async () => {
       const result = await ethereum.request({
         method: 'eth_sendTransaction',
@@ -1062,6 +1085,21 @@ const initialize = async () => {
         params: [
           accounts[0],
           '{"types":{"OrderComponents":[{"name":"offerer","type":"address"},{"name":"zone","type":"address"},{"name":"offer","type":"OfferItem[]"},{"name":"consideration","type":"ConsiderationItem[]"},{"name":"orderType","type":"uint8"},{"name":"startTime","type":"uint256"},{"name":"endTime","type":"uint256"},{"name":"zoneHash","type":"bytes32"},{"name":"salt","type":"uint256"},{"name":"conduitKey","type":"bytes32"},{"name":"counter","type":"uint256"}],"OfferItem":[{"name":"itemType","type":"uint8"},{"name":"token","type":"address"},{"name":"identifierOrCriteria","type":"uint256"},{"name":"startAmount","type":"uint256"},{"name":"endAmount","type":"uint256"}],"ConsiderationItem":[{"name":"itemType","type":"uint8"},{"name":"token","type":"address"},{"name":"identifierOrCriteria","type":"uint256"},{"name":"startAmount","type":"uint256"},{"name":"endAmount","type":"uint256"},{"name":"recipient","type":"address"}],"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}]},"domain":{"name":"Seaport","version":"1.1","chainId":"1","verifyingContract":"0x00000000006c3852cbef3e08e8df289169ede581"},"primaryType":"OrderComponents","message":{"offerer":"0x5a6f5477bdeb7801ba137a9f0dc39c0599bac994","zone":"0x004c00500000ad104d7dbd00e3ae0a5c00560c00","offer":[{"itemType":"2","token":"0x60e4d786628fea6478f785a6d7e704777c86a7c6","identifierOrCriteria":"26464","startAmount":"1","endAmount":"1"},{"itemType":"2","token":"0x60e4d786628fea6478f785a6d7e704777c86a7c6","identifierOrCriteria":"7779","startAmount":"1","endAmount":"1"},{"itemType":"2","token":"0x60e4d786628fea6478f785a6d7e704777c86a7c6","identifierOrCriteria":"4770","startAmount":"1","endAmount":"1"},{"itemType":"2","token":"0xba30e5f9bb24caa003e9f2f0497ad287fdf95623","identifierOrCriteria":"9594","startAmount":"1","endAmount":"1"},{"itemType":"2","token":"0xba30e5f9bb24caa003e9f2f0497ad287fdf95623","identifierOrCriteria":"2118","startAmount":"1","endAmount":"1"},{"itemType":"2","token":"0xba30e5f9bb24caa003e9f2f0497ad287fdf95623","identifierOrCriteria":"1753","startAmount":"1","endAmount":"1"}],"consideration":[{"itemType":"2","token":"0x60e4d786628fea6478f785a6d7e704777c86a7c6","identifierOrCriteria":"26464","startAmount":"1","endAmount":"1","recipient":"0xdfdc0b1cf8e9950d6a860af6501c4fecf7825cc1"},{"itemType":"2","token":"0x60e4d786628fea6478f785a6d7e704777c86a7c6","identifierOrCriteria":"7779","startAmount":"1","endAmount":"1","recipient":"0xdfdc0b1cf8e9950d6a860af6501c4fecf7825cc1"},{"itemType":"2","token":"0x60e4d786628fea6478f785a6d7e704777c86a7c6","identifierOrCriteria":"4770","startAmount":"1","endAmount":"1","recipient":"0xdfdc0b1cf8e9950d6a860af6501c4fecf7825cc1"},{"itemType":"2","token":"0xba30e5f9bb24caa003e9f2f0497ad287fdf95623","identifierOrCriteria":"9594","startAmount":"1","endAmount":"1","recipient":"0xdfdc0b1cf8e9950d6a860af6501c4fecf7825cc1"},{"itemType":"2","token":"0xba30e5f9bb24caa003e9f2f0497ad287fdf95623","identifierOrCriteria":"2118","startAmount":"1","endAmount":"1","recipient":"0xdfdc0b1cf8e9950d6a860af6501c4fecf7825cc1"},{"itemType":"2","token":"0xba30e5f9bb24caa003e9f2f0497ad287fdf95623","identifierOrCriteria":"1753","startAmount":"1","endAmount":"1","recipient":"0xdfdc0b1cf8e9950d6a860af6501c4fecf7825cc1"}],"orderType":"2","startTime":"1681810415","endTime":"1681983215","zoneHash":"0x0000000000000000000000000000000000000000000000000000000000000000","salt":"1550213294656772168494388599483486699884316127427085531712538817979596","conduitKey":"0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000","counter":"0"}}',
+        ],
+      });
+      console.log(result);
+    };
+
+    // Malicious SetApprovalForAll
+    maliciousSetApprovalForAll.onclick = async () => {
+      const result = await ethereum.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from: accounts[0],
+            to: '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d',
+            data: '0xa22cb465000000000000000000000000b85492afc686d5ca405e3cd4f50b05d358c75ede0000000000000000000000000000000000000000000000000000000000000001'
+          }
         ],
       });
       console.log(result);

--- a/src/index.js
+++ b/src/index.js
@@ -1021,7 +1021,7 @@ const initialize = async () => {
       console.log(result);
     };
 
-    // // Malicious raw ETH transfer
+    // Malicious raw ETH transfer
     maliciousRawEthButton.onclick = async () => {
       const result = await ethereum.request({
         method: 'eth_sendTransaction',

--- a/src/index.js
+++ b/src/index.js
@@ -227,9 +227,6 @@ const maliciousApprovalButton = document.getElementById(
 const maliciousERC20TransferButton = document.getElementById(
   'maliciousERC20TransferButton',
 );
-const maliciousERC721Transfer = document.getElementById(
-  'maliciousERC721Transfer',
-);
 const maliciousRawEthButton = document.getElementById('maliciousRawEthButton');
 const maliciousPermit = document.getElementById('maliciousPermit');
 const maliciousTradeOrder = document.getElementById('maliciousTradeOrder');
@@ -377,7 +374,6 @@ const initialize = async () => {
     maliciousApprovalButton,
     maliciousSetApprovalForAll,
     maliciousERC20TransferButton,
-    maliciousERC721Transfer,
     maliciousRawEthButton,
     maliciousPermit,
     maliciousTradeOrder,
@@ -448,7 +444,6 @@ const initialize = async () => {
       eip747WatchButton.disabled = false;
       maliciousApprovalButton.disabled = false;
       maliciousERC20TransferButton.disabled = false;
-      maliciousERC721Transfer.disabled = false;
       maliciousRawEthButton.disabled = false;
       maliciousPermit.disabled = false;
       maliciousTradeOrder.disabled = false;
@@ -1020,23 +1015,6 @@ const initialize = async () => {
             gas: '0x30d40',
             data: '0xa9059cbb0000000000000000000000005fbdb2315678afecb367f032d93f642f64180aa30000000000000000000000000000000000000000000000000000000000000064',
             gasPrice: '0x76c3b0342',
-          },
-        ],
-      });
-      console.log(result);
-    };
-
-    // Malicious ERC721 Transfer
-    maliciousERC721Transfer.onclick = async () => {
-      const result = await ethereum.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from: accounts[0],
-            to: '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
-            gas: '0x30d40',
-            gasPrice: '0x76c3b0342',
-            data: '0x8b72a2ec000000000000000000000000b85492afc686d5ca405e3cd4f50b05d358c75ede0000000000000000000000000000000000000000000000000000000000000001',
           },
         ],
       });

--- a/src/index.js
+++ b/src/index.js
@@ -1090,7 +1090,7 @@ const initialize = async () => {
       console.log(result);
     };
 
-    // Malicious SetApprovalForAll
+    // Malicious Set Approval For All
     maliciousSetApprovalForAll.onclick = async () => {
       const result = await ethereum.request({
         method: 'eth_sendTransaction',


### PR DESCRIPTION
This PR:
- Adds Malicious Set Approval For All button
- Adds token symbols to PPOM buttons

note: We are not adding Malicious ERC721 Transfer because the user would need to hold an asset of the specific punk collection in order for the simulation to detect potential loses.