### PR TITLE
Adds Send ETH and SendERC20 Deeplink for Mobile e2e

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -157,6 +157,15 @@
                 >
                   Send EIP 1559 Transaction
                 </button>
+                <a href="https://metamask.app.link/send/0x2f318C334780961FB129D2a6c30D0763d9a5C970?value=1e13">
+                  <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="sendEthDeeplink"
+                  enabled
+                  >
+                  Send ETH Deeplink (Mobile Only)
+                  </button>
+                </a>
                 <hr />
                 <h4 class="card-title">
                   Piggy bank contract
@@ -291,7 +300,14 @@
                 >
                   Transfer Tokens
                 </button>
-
+                <a id="transferTokensDeeplink" >
+                  <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  enabled
+                  >
+                    Transfer Tokens Deeplink (Mobile Only)
+                  </button>
+                </a>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="approveTokens"

--- a/src/index.js
+++ b/src/index.js
@@ -137,6 +137,9 @@ const tokenAddresses = document.getElementById('tokenAddresses');
 const createToken = document.getElementById('createToken');
 const watchAssets = document.getElementById('watchAssets');
 const transferTokens = document.getElementById('transferTokens');
+const transferTokensDeeplink = document.getElementById(
+  'transferTokensDeeplink',
+);
 const approveTokens = document.getElementById('approveTokens');
 const transferTokensWithoutGas = document.getElementById(
   'transferTokensWithoutGas',
@@ -473,6 +476,10 @@ const initialize = async () => {
     }
 
     if (deployedContractAddress) {
+      // Deeplink
+      const erc20Decimals = '4';
+      const deeplink = `https://metamask.app.link/send/${deployedContractAddress}/transfer?address=0x2f318C334780961FB129D2a6c30D0763d9a5C970&uint256=3e${erc20Decimals}`;
+      transferTokensDeeplink.setAttribute('href', deeplink);
       // Piggy bank contract
       contractStatus.innerHTML = 'Deployed';
       depositButton.disabled = false;


### PR DESCRIPTION
In this PR we add the ability to use Deeplinks for writting Mobile e2e testcases around this feature. Considerations:
- Send ETH using Deeplink and Send ERC20 using Deeplink have been added
- Those functionalities can only be tested using Mobile and with a regular browser (not with the in wallet browser)
- Since a regular browser is used, we need the buttons to be always enabled (no matter if you are connected to the test dapp - since you won't be able to be connected)
- Since the provider won't be found (you are using a regular browser), we cannot access to the functionalities of the provider, meaning we cannot get the decimals for the ERC20 token dynamically, so the default `4` decimals is used


## Send ETH Deeplink
https://github.com/MetaMask/test-dapp/assets/54408225/ccfdfa20-ff03-40b0-98d6-35b6f2082ae6

## Send ERC20 Deeplink
https://github.com/MetaMask/test-dapp/assets/54408225/d6b79dc8-01d5-4c57-b3c0-12abbc2447f6


