### PR TITLE
release v7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.2.0]
+
+### Added
+- Add ability to mint and and watch (via `wallet_watchAsset`) multiple ERC20 tokens. ([#259](https://github.com/MetaMask/test-dapp/pull/259))
+- Add malicious `setApprovalForAll` button testing blockaid/ppom module. ([#258](https://github.com/MetaMask/test-dapp/pull/258))
+
+### Fixed
+- Fix issue where chainId and networkId were represented as interchangeable ([#256](https://github.com/MetaMask/test-dapp/pull/256))
+- Fix issue where legacy eth send transactions did not have the correct gasLimit value ([#257](https://github.com/MetaMask/test-dapp/pull/257))
+
+
 ## [7.1.0]
 ### Added
 - Add PPOM testing section ([#253](https://github.com/MetaMask/test-dapp/pull/253))
@@ -109,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
-[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v7.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v7.2.0...HEAD
+[7.1.0]: https://github.com/MetaMask/test-dapp/compare/v7.1.0...v7.2.0
 [7.1.0]: https://github.com/MetaMask/test-dapp/compare/v7.0.2...v7.1.0
 [7.0.2]: https://github.com/MetaMask/test-dapp/compare/v7.0.1...v7.0.2
 [7.0.1]: https://github.com/MetaMask/test-dapp/compare/v7.0.0...v7.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 16.0.0"


### PR DESCRIPTION
## [7.2.0]

### Added
- Add ability to mint and and watch (via `wallet_watchAsset`) multiple ERC20 tokens. ([#259](https://github.com/MetaMask/test-dapp/pull/259))
- Add malicious `setApprovalForAll` button testing blockaid/ppom module. ([#258](https://github.com/MetaMask/test-dapp/pull/258))

### Fixed
- Fix issue where chainId and networkId were represented as interchangeable ([#256](https://github.com/MetaMask/test-dapp/pull/256))
- Fix issue where legacy eth send transactions did not have the correct gasLimit value ([#257](https://github.com/MetaMask/test-dapp/pull/257))
