### PR TITLE
feat: add `transferFrom` and `approve` to input address for ERC20 contract

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -364,7 +364,7 @@
                   <label>From</label>
                   <input
                     class="form-control"
-                    id="senderInput"
+                    id="transferFromSenderInput"
                   />
                 </div>
 
@@ -372,7 +372,7 @@
                   <label>To</label>
                   <input
                     class="form-control"
-                    id="recipientInput"
+                    id="transferFromRecipientInput"
                   />
                 </div>
                 <button

--- a/src/index.html
+++ b/src/index.html
@@ -343,6 +343,15 @@
                   Transfer Tokens
                 </button>
 
+                <div class="form-group">
+                  <label>Approve to Address</label>
+                  <input
+                    class="form-control"
+                    id="approveTo"
+                    value="0x9bc5baF874d2DA8D216aE9f137804184EE5AfEF4"
+                  />
+                </div>
+
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="approveTokens"
@@ -351,6 +360,28 @@
                   Approve Tokens
                 </button>
 
+                <div class="form-group">
+                  <label>From</label>
+                  <input
+                    class="form-control"
+                    id="senderInput"
+                  />
+                </div>
+
+                <div class="form-group">
+                  <label>To</label>
+                  <input
+                    class="form-control"
+                    id="recipientInput"
+                  />
+                </div>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="transferFromTokens"
+                  disabled
+                >
+                  Transfer From Tokens
+                </button>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="transferTokensWithoutGas"

--- a/src/index.html
+++ b/src/index.html
@@ -361,7 +361,7 @@
                 </button>
 
                 <div class="form-group">
-                  <label>From</label>
+                  <label>Transfer From</label>
                   <input
                     class="form-control"
                     id="transferFromSenderInput"
@@ -369,7 +369,7 @@
                 </div>
 
                 <div class="form-group">
-                  <label>To</label>
+                  <label>Transfer To</label>
                   <input
                     class="form-control"
                     id="transferFromRecipientInput"

--- a/src/index.js
+++ b/src/index.js
@@ -138,11 +138,15 @@ const sendEIP1559Button = document.getElementById('sendEIP1559Button');
 
 // Send Tokens Section
 const decimalUnitsInput = document.getElementById('tokenDecimals');
+const approveToInput = document.getElementById('approveTo');
+const senderInput = document.getElementById('senderInput');
+const recipientInput = document.getElementById('recipientInput');
 const tokenSymbol = 'TST';
 const tokenAddresses = document.getElementById('tokenAddresses');
 const createToken = document.getElementById('createToken');
 const watchAssets = document.getElementById('watchAssets');
 const transferTokens = document.getElementById('transferTokens');
+const transferFromTokens = document.getElementById('transferFromTokens');
 const approveTokens = document.getElementById('approveTokens');
 const transferTokensWithoutGas = document.getElementById(
   'transferTokensWithoutGas',
@@ -271,8 +275,10 @@ const allConnectedButtons = [
   sendButton,
   createToken,
   decimalUnitsInput,
+  approveToInput,
   watchAssets,
   transferTokens,
+  transferFromTokens,
   approveTokens,
   transferTokensWithoutGas,
   approveTokensWithoutGas,
@@ -316,6 +322,7 @@ const initialConnectedButtons = [
   deployMultisigButton,
   createToken,
   decimalUnitsInput,
+  approveToInput,
   personalSign,
   signTypedData,
   getEncryptionKeyButton,
@@ -806,6 +813,7 @@ const updateContractElements = () => {
     tokenAddresses.innerHTML = hstContract ? hstContract.address : '';
     watchAssets.disabled = false;
     transferTokens.disabled = false;
+    transferFromTokens.disabled = false;
     approveTokens.disabled = false;
     transferTokensWithoutGas.disabled = false;
     approveTokensWithoutGas.disabled = false;
@@ -1424,6 +1432,7 @@ const initializeFormElements = () => {
       .join(', ');
     watchAssets.disabled = false;
     transferTokens.disabled = false;
+    transferFromTokens.disabled = false;
     approveTokens.disabled = false;
     transferTokensWithoutGas.disabled = false;
     approveTokensWithoutGas.disabled = false;
@@ -1469,11 +1478,27 @@ const initializeFormElements = () => {
 
   approveTokens.onclick = async () => {
     const result = await hstContract.approve(
-      '0x9bc5baF874d2DA8D216aE9f137804184EE5AfEF4',
+      approveToInput.value,
       `${7 * 10 ** decimalUnitsInput.value}`,
       {
         from: accounts[0],
         gasLimit: 60000,
+        gasPrice: '20000000000',
+      },
+    );
+    console.log('result', result);
+  };
+
+  transferFromTokens.onclick = async () => {
+    const result = await hstContract.transferFrom(
+      senderInput.value,
+      recipientInput.value,
+      decimalUnitsInput.value === '0'
+        ? 1
+        : `${1.5 * 10 ** decimalUnitsInput.value}`,
+      {
+        from: accounts[0],
+        gasLimit: '95000',
         gasPrice: '20000000000',
       },
     );

--- a/src/index.js
+++ b/src/index.js
@@ -138,9 +138,13 @@ const sendEIP1559Button = document.getElementById('sendEIP1559Button');
 
 // Send Tokens Section
 const decimalUnitsInput = document.getElementById('tokenDecimals');
-const approveToInput = document.getElementById('approveTo');
-const senderInput = document.getElementById('senderInput');
-const recipientInput = document.getElementById('recipientInput');
+const approveTokensToInput = document.getElementById('approveTo');
+const transferFromSenderInput = document.getElementById(
+  'transferFromSenderInput',
+);
+const transferFromRecipientInput = document.getElementById(
+  'transferFromRecipientInput',
+);
 const tokenSymbol = 'TST';
 const tokenAddresses = document.getElementById('tokenAddresses');
 const createToken = document.getElementById('createToken');
@@ -275,11 +279,13 @@ const allConnectedButtons = [
   sendButton,
   createToken,
   decimalUnitsInput,
-  approveToInput,
+  approveTokensToInput,
   watchAssets,
   transferTokens,
   transferFromTokens,
   approveTokens,
+  transferFromRecipientInput,
+  transferFromSenderInput,
   transferTokensWithoutGas,
   approveTokensWithoutGas,
   getEncryptionKeyButton,
@@ -322,7 +328,6 @@ const initialConnectedButtons = [
   deployMultisigButton,
   createToken,
   decimalUnitsInput,
-  approveToInput,
   personalSign,
   signTypedData,
   getEncryptionKeyButton,
@@ -817,6 +822,9 @@ const updateContractElements = () => {
     approveTokens.disabled = false;
     transferTokensWithoutGas.disabled = false;
     approveTokensWithoutGas.disabled = false;
+    transferFromSenderInput.disabled = false;
+    approveTokensToInput.disabled = false;
+    transferFromRecipientInput.disabled = false;
   }
 };
 
@@ -1436,6 +1444,9 @@ const initializeFormElements = () => {
     approveTokens.disabled = false;
     transferTokensWithoutGas.disabled = false;
     approveTokensWithoutGas.disabled = false;
+    approveTokensToInput.disabled = false;
+    transferFromSenderInput.disabled = false;
+    transferFromRecipientInput.disabled = false;
   };
 
   watchAssets.onclick = async () => {
@@ -1478,7 +1489,7 @@ const initializeFormElements = () => {
 
   approveTokens.onclick = async () => {
     const result = await hstContract.approve(
-      approveToInput.value,
+      approveTokensToInput.value,
       `${7 * 10 ** decimalUnitsInput.value}`,
       {
         from: accounts[0],
@@ -1491,8 +1502,8 @@ const initializeFormElements = () => {
 
   transferFromTokens.onclick = async () => {
     const result = await hstContract.transferFrom(
-      senderInput.value,
-      recipientInput.value,
+      transferFromSenderInput.value,
+      transferFromRecipientInput.value,
       decimalUnitsInput.value === '0'
         ? 1
         : `${1.5 * 10 ** decimalUnitsInput.value}`,


### PR DESCRIPTION
## What
This PR adds the ability to perform `transferFrom` function calls, and do the complete flow (from approve to transfer from) dynamically to the desired addresses.
Notice the ERC20 token already had `transferFrom` and `approve` support, so there is no need to change anything on the contract level.

## How
- The default address for the `approve` input is the one that was previously hardcoded. The reason for that is because this way, we don't need to change any existing e2e tests relying on approving to that address. You can change the address just by entering a different input
- The `transferFrom` addresses can be changed dynamically with an input element
- The `approve` amount is still hardcoded, as this can be changed from the UI if desired
- The `transferFrom` amount is hardcoded, as there is no relevance on which amount we are transferring

## Screenshots
- UI

![Screenshot from 2023-11-07 13-02-24](https://github.com/MetaMask/test-dapp/assets/54408225/6d2f4c4c-3359-42b3-b690-4898aabe4955)


- Transfer From complete flow

https://github.com/MetaMask/test-dapp/assets/54408225/ceecfec8-163a-4f27-8a25-ccb29d696395

## Manual Testing Steps

1. Deploy an ERC20 token contract
2. Approve from address A to address B
3. Change to address B
4. Perform a transfer from, from address A to address B

