### PR TITLE
Update `eth_signTypedData_v4` example

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2111,6 +2111,7 @@ const initializeFormElements = () => {
             ],
           },
         ],
+        attachment: '0x',
       },
       primaryType: 'Mail',
       types: {
@@ -2128,6 +2129,7 @@ const initializeFormElements = () => {
           { name: 'from', type: 'Person' },
           { name: 'to', type: 'Person[]' },
           { name: 'contents', type: 'string' },
+          { name: 'attachment', type: 'bytes' },
         ],
         Person: [
           { name: 'name', type: 'string' },
@@ -2181,6 +2183,7 @@ const initializeFormElements = () => {
             ],
           },
         ],
+        attachment: '0x',
       },
       primaryType: 'Mail',
       types: {
@@ -2198,6 +2201,7 @@ const initializeFormElements = () => {
           { name: 'from', type: 'Person' },
           { name: 'to', type: 'Person[]' },
           { name: 'contents', type: 'string' },
+          { name: 'attachment', type: 'bytes' },
         ],
         Person: [
           { name: 'name', type: 'string' },


### PR DESCRIPTION
The example `eth_signTypedData_v4` message has been updated to include a field that can reproduce this bug: https://github.com/MetaMask/metamask-mobile/issues/7792 That signing bug results in invalid signatures for any messages that include a `bytes` field with the value `0x`.