### PR TITLE
Fix allow-scripts integration

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
+      - run: yarn allow-scripts
       - run: yarn build
       - run: yarn lint
       - run: yarn test

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {},
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.5.1",
+    "@lavamoat/preinstall-always-fail": "^2.0.0",
     "@metamask/auto-changelog": "^2.5.0",
     "@metamask/eslint-config": "^6.0.0",
     "@metamask/eslint-config-nodejs": "^6.0.0",
@@ -62,9 +63,9 @@
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,
-      "eth-sig-util>ethereumjs-abi>ethereumjs-util>keccakjs>sha3": true,
-      "ethereumjs-util>keccak": true,
-      "ethereumjs-util>secp256k1": true
+      "eth-sig-util>ethereumjs-abi>ethereumjs-util>keccakjs>sha3": false,
+      "ethereumjs-util>keccak": false,
+      "ethereumjs-util>secp256k1": false
     }
   },
   "packageManager": "yarn@1.22.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,6 +449,11 @@
     npm-normalize-package-bin "^3.0.0"
     yargs "^16.2.0"
 
+"@lavamoat/preinstall-always-fail@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@lavamoat/preinstall-always-fail/-/preinstall-always-fail-2.0.0.tgz#06813fc43d6f08e14045254278c1978b04b34631"
+  integrity sha512-7sgV9DtAD7z7nhxLb2vSjEqgjd3xVk2CbZKwBDVFXkZk1L6xrOIaJTNv5rgNy801/Rjc54KyJ48fHR3djwU35A==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"


### PR DESCRIPTION
The `@lavamoat/allow-scripts` integration was not setup correctly.

* The `@lavamoat/preinstall-always-fail` package was missing, despite being referenced in the configuration
* Various packages had their install scripts allowed, but they were not necessary and they failed when run.
* The `allow-scripts` step was not run in CI

All of these issues have been resolved.