### PR TITLE
Add wallet_revokePermissions for eth_accounts

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -173,9 +173,9 @@
                 </button>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
-                  id="revokeAccountsPermissions"
+                  id="revokeAccountsPermission"
                 >
-                  Revoke Account Permissions
+                  Revoke Accounts Permission
                 </button>
 
                 <p class="info-text alert alert-secondary">

--- a/src/index.html
+++ b/src/index.html
@@ -171,6 +171,12 @@
                 >
                   Get Permissions
                 </button>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="revokeAccountsPermissions"
+                >
+                  Revoke Account Permissions
+                </button>
 
                 <p class="info-text alert alert-secondary">
                   Permissions result: <span id="permissionsResult"></span>

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,9 @@ const getAccountsResult = document.getElementById('getAccountsResult');
 const requestPermissionsButton = document.getElementById('requestPermissions');
 const getPermissionsButton = document.getElementById('getPermissions');
 const permissionsResult = document.getElementById('permissionsResult');
+const revokeAccountPermissionButton = document.getElementById(
+  'revokeAccountsPermissions',
+);
 
 // Contract Section
 const deployButton = document.getElementById('deployButton');
@@ -1606,6 +1609,21 @@ const initializeFormElements = () => {
     } catch (err) {
       console.error(err);
       getAccountsResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  revokeAccountPermissionButton.onclick = async () => {
+    try {
+      await provider.request({
+        method: 'wallet_revokePermissions',
+        params: [
+          {
+            eth_accounts: {},
+          },
+        ],
+      });
+    } catch (err) {
+      permissionsResult.innerHTML = `${err.message}`;
     }
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,8 @@ const getAccountsResult = document.getElementById('getAccountsResult');
 const requestPermissionsButton = document.getElementById('requestPermissions');
 const getPermissionsButton = document.getElementById('getPermissions');
 const permissionsResult = document.getElementById('permissionsResult');
-const revokeAccountPermissionButton = document.getElementById(
-  'revokeAccountsPermissions',
+const revokeAccountsPermissionButton = document.getElementById(
+  'revokeAccountsPermission',
 );
 
 // Contract Section
@@ -1612,7 +1612,7 @@ const initializeFormElements = () => {
     }
   };
 
-  revokeAccountPermissionButton.onclick = async () => {
+  revokeAccountsPermissionButton.onclick = async () => {
     try {
       await provider.request({
         method: 'wallet_revokePermissions',


### PR DESCRIPTION
Adds `wallet_revokePermissions` for `eth_accounts` button under the Permissions Actions card.


https://github.com/MetaMask/test-dapp/assets/13376180/ba2b3196-b37e-42b2-bba3-68703e6a47d5

