### PR TITLE
fix: remove suggested gas from malicious transactions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1304,9 +1304,7 @@ const initializeFormElements = () => {
         {
           from: accounts[0],
           to: '0x4fabb145d64652a948d72533023f6e7a623c7c53',
-          gas: '0x30d40',
           data: '0x095ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6000000000000000000000000000000000000000000000000ffffffffffffffff',
-          gasPrice: '0x76c3b0342',
         },
       ],
     });
@@ -1321,9 +1319,7 @@ const initializeFormElements = () => {
         {
           from: accounts[0],
           to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-          gas: '0x30d40',
           data: '0xa9059cbb0000000000000000000000005fbdb2315678afecb367f032d93f642f64180aa30000000000000000000000000000000000000000000000000000000000000064',
-          gasPrice: '0x76c3b0342',
         },
       ],
     });


### PR DESCRIPTION
## Description
This is a small fix that removes the suggested gas values from the malicious transactions. This increases the chance for the transactions to be flagged as malicious, as the gas set was a bit high, making the validation fail with `not enough funds` error, if the account don't have enough ETH

## Screenshots
Before (test-dapp)
After (localhost)

https://github.com/MetaMask/test-dapp/assets/54408225/9af807ee-ada6-4aa6-abb2-ffbee475953e

