### PR TITLE
add: support malicious tx's in multiple networks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1309,12 +1309,19 @@ const initializeFormElements = () => {
 
   // Malicious ERC20 Approval
   maliciousApprovalButton.onclick = async () => {
+    let erc20Contract;
+
+    if (networkName) {
+      erc20Contract = ERC20_SAMPLE_CONTRACTS[networkName];
+    } else {
+      erc20Contract = '0x4fabb145d64652a948d72533023f6e7a623c7c53';
+    }
     const result = await ethereum.request({
       method: 'eth_sendTransaction',
       params: [
         {
           from: accounts[0],
-          to: `${ERC20_SAMPLE_CONTRACTS[networkName]}`,
+          to: erc20Contract,
           gas: '0x30d40',
           data: '0x095ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6000000000000000000000000000000000000000000000000ffffffffffffffff',
           gasPrice: '0x76c3b0342',
@@ -1326,15 +1333,21 @@ const initializeFormElements = () => {
 
   // Malicious ERC20 transfer
   maliciousERC20TransferButton.onclick = async () => {
+    let erc20Contract;
+
+    if (networkName) {
+      erc20Contract = ERC20_SAMPLE_CONTRACTS[networkName];
+    } else {
+      erc20Contract = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+    }
+
     const result = await ethereum.request({
       method: 'eth_sendTransaction',
       params: [
         {
           from: accounts[0],
-          to: `${ERC20_SAMPLE_CONTRACTS[networkName]}`,
-          gas: '0x30d40',
+          to: erc20Contract,
           data: '0xa9059cbb0000000000000000000000005fbdb2315678afecb367f032d93f642f64180aa30000000000000000000000000000000000000000000000000000000000000064',
-          gasPrice: '0x76c3b0342',
         },
       ],
     });
@@ -1394,12 +1407,20 @@ const initializeFormElements = () => {
 
   // Malicious Set Approval For All
   maliciousSetApprovalForAll.onclick = async () => {
+    let erc721Contract;
+
+    if (networkName) {
+      erc721Contract = ERC721_SAMPLE_CONTRACTS[networkName];
+    } else {
+      erc721Contract = '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d';
+    }
+
     const result = await ethereum.request({
       method: 'eth_sendTransaction',
       params: [
         {
           from: accounts[0],
-          to: `${ERC721_SAMPLE_CONTRACTS[networkName]}`,
+          to: erc721Contract,
           data: '0xa22cb465000000000000000000000000b85492afc686d5ca405e3cd4f50b05d358c75ede0000000000000000000000000000000000000000000000000000000000000001',
         },
       ],

--- a/src/index.js
+++ b/src/index.js
@@ -1322,9 +1322,7 @@ const initializeFormElements = () => {
         {
           from: accounts[0],
           to: erc20Contract,
-          gas: '0x30d40',
           data: '0x095ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6000000000000000000000000000000000000000000000000ffffffffffffffff',
-          gasPrice: '0x76c3b0342',
         },
       ],
     });

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,11 @@ import { ethers } from 'ethers';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { getPermissionsDisplayString, stringifiableToHex } from './utils';
 import Constants from './constants.json';
+import {
+  NETWORKS_BY_CHAIN_ID,
+  ERC20_SAMPLE_CONTRACTS,
+  ERC721_SAMPLE_CONTRACTS,
+} from './onchain-sample-contracts';
 
 const {
   hstBytecode,
@@ -489,11 +494,13 @@ const handleNewAccounts = (newAccounts) => {
 };
 
 let chainIdInt;
+let networkName;
 
 const handleNewChain = (chainId) => {
   chainIdDiv.innerHTML = chainId;
   const networkId = parseInt(networkDiv.innerHTML, 10);
   chainIdInt = parseInt(chainIdDiv.innerHTML, 16) || networkId;
+  networkName = NETWORKS_BY_CHAIN_ID[chainIdInt];
 
   if (chainId === '0x1') {
     warningDiv.classList.remove('warning-invisible');
@@ -1307,7 +1314,7 @@ const initializeFormElements = () => {
       params: [
         {
           from: accounts[0],
-          to: '0x4fabb145d64652a948d72533023f6e7a623c7c53',
+          to: `${ERC20_SAMPLE_CONTRACTS[networkName]}`,
           gas: '0x30d40',
           data: '0x095ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6000000000000000000000000000000000000000000000000ffffffffffffffff',
           gasPrice: '0x76c3b0342',
@@ -1324,7 +1331,7 @@ const initializeFormElements = () => {
       params: [
         {
           from: accounts[0],
-          to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          to: `${ERC20_SAMPLE_CONTRACTS[networkName]}`,
           gas: '0x30d40',
           data: '0xa9059cbb0000000000000000000000005fbdb2315678afecb367f032d93f642f64180aa30000000000000000000000000000000000000000000000000000000000000064',
           gasPrice: '0x76c3b0342',
@@ -1367,7 +1374,7 @@ const initializeFormElements = () => {
       method: 'eth_signTypedData_v4',
       params: [
         accounts[0],
-        `{"types":{"ERC721Order":[{"type":"uint8","name":"direction"},{"type":"address","name":"maker"},{"type":"address","name":"taker"},{"type":"uint256","name":"expiry"},{"type":"uint256","name":"nonce"},{"type":"address","name":"erc20Token"},{"type":"uint256","name":"erc20TokenAmount"},{"type":"Fee[]","name":"fees"},{"type":"address","name":"erc721Token"},{"type":"uint256","name":"erc721TokenId"},{"type":"Property[]","name":"erc721TokenProperties"}],"Fee":[{"type":"address","name":"recipient"},{"type":"uint256","name":"amount"},{"type":"bytes","name":"feeData"}],"Property":[{"type":"address","name":"propertyValidator"},{"type":"bytes","name":"propertyData"}],"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}]},"domain":{"name":"ZeroEx","version":"1.0.0","chainId":${chainIdInt},"verifyingContract":"0xdef1c0ded9bec7f1a1670819833240f027b25eff"},"primaryType":"ERC721Order","message":{"direction":"0","maker":"${accounts[0]}","taker":"0x0000000000000000000000000000000000000000","expiry":"2524604400","nonce":"100131415900000000000000000000000000000083840314483690155566137712510085002484","erc20Token":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","erc20TokenAmount":"42000000000000","fees":[],"erc721Token":"0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e","erc721TokenId":"2516","erc721TokenProperties":[]}}`,
+        `{"types":{"ERC721Order":[{"type":"uint8","name":"direction"},{"type":"address","name":"maker"},{"type":"address","name":"taker"},{"type":"uint256","name":"expiry"},{"type":"uint256","name":"nonce"},{"type":"address","name":"erc20Token"},{"type":"uint256","name":"erc20TokenAmount"},{"type":"Fee[]","name":"fees"},{"type":"address","name":"erc721Token"},{"type":"uint256","name":"erc721TokenId"},{"type":"Property[]","name":"erc721TokenProperties"}],"Fee":[{"type":"address","name":"recipient"},{"type":"uint256","name":"amount"},{"type":"bytes","name":"feeData"}],"Property":[{"type":"address","name":"propertyValidator"},{"type":"bytes","name":"propertyData"}],"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}]},"domain":{"name":"ZeroEx","version":"1.0.0","chainId":${chainIdInt},"verifyingContract":"0xdef1c0ded9bec7f1a1670819833240f027b25eff"},"primaryType":"ERC721Order","message":{"direction":"0","maker":"${accounts[0]}","taker":"0x5FbDB2315678afecb367f032d93F642f64180aa3","expiry":"2524604400","nonce":"100131415900000000000000000000000000000083840314483690155566137712510085002484","erc20Token":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","erc20TokenAmount":"42000000000000","fees":[],"erc721Token":"0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e","erc721TokenId":"2516","erc721TokenProperties":[]}}`,
       ],
     });
     console.log(result);
@@ -1392,7 +1399,7 @@ const initializeFormElements = () => {
       params: [
         {
           from: accounts[0],
-          to: '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d',
+          to: `${ERC721_SAMPLE_CONTRACTS[networkName]}`,
           data: '0xa22cb465000000000000000000000000b85492afc686d5ca405e3cd4f50b05d358c75ede0000000000000000000000000000000000000000000000000000000000000001',
         },
       ],

--- a/src/onchain-sample-contracts.js
+++ b/src/onchain-sample-contracts.js
@@ -1,0 +1,24 @@
+// Contracts for Malicious Transactions in different chains
+export const NETWORKS_BY_CHAIN_ID = {
+  137: 'polygon',
+  10: 'optimism',
+  56: 'bsc',
+  43114: 'avalanche',
+  42161: 'arbitrum',
+};
+
+export const ERC20_SAMPLE_CONTRACTS = {
+  polygon: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+  optimism: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+  bsc: '0x8965349fb649A33a30cbFDa057D8eC2C48AbE2A2',
+  avalanche: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
+  arbitrum: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+};
+
+export const ERC721_SAMPLE_CONTRACTS = {
+  polygon: '0x9e8ea82e76262e957d4cc24e04857a34b0d8f062',
+  optimism: '0xaf18644083151cf57f914cccc23c42a1892c218e',
+  bsc: '0xebfbfd7c41b123500fb16b71c43b400c12b08be0',
+  avalanche: '0x880f7e04D722e305126F7E1efd3434A7d5b1465c',
+  arbitrum: '0x8659a4876369b94515a86048fe7f99daba6b9a7d',
+};


### PR DESCRIPTION
## Description
The PPOM module now is supported in more networks. For that reason, we need to update the transactions in order to point to the correct contract addresses according to the network we have selected.
The Trade Order signature also needs to be changed, as the previous one was not flagged in all networks.
Notice for seeing the Malicious warning, you need to have some balance, for paying the gas for the transactions, and a small amount of the ERC20 token for the Transfer transaction, on each chain.

Pending (in progress)
- [x] handle mainnet (2 diff ERC20)
- [x] handle other not supported networks

## Screenshots

https://github.com/MetaMask/test-dapp/assets/54408225/5d6b45aa-5a71-4eb4-b00a-7be6c0618ac0

