### PR TITLE
Release Candidate v8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [8.1.0]
+### Added
+- Add support for ppom malicious transactions in multiple networks ([#281](https://github.com/MetaMask/test-dapp/pull/281))
+- Add support for ppom malicious signatures in multiple networks ([#279](https://github.com/MetaMask/test-dapp/pull/279))
+- Add `wallet_revokePermissions` for `eth_accounts` ([#278](https://github.com/MetaMask/test-dapp/pull/278))
 
 ## [8.0.0]
 ### Added
@@ -137,7 +142,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
-[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v8.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v8.1.0...HEAD
+[8.1.0]: https://github.com/MetaMask/test-dapp/compare/v8.0.0...v8.1.0
 [8.0.0]: https://github.com/MetaMask/test-dapp/compare/v7.3.1...v8.0.0
 [7.3.1]: https://github.com/MetaMask/test-dapp/compare/v7.3.0...v7.3.1
 [7.3.0]: https://github.com/MetaMask/test-dapp/compare/v7.2.0...v7.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 18.0.0"


### PR DESCRIPTION
This is the release candidate PR for `v8.1.0`

### Added
- Add support for ppom malicious transactions in multiple networks ([#281](https://github.com/MetaMask/test-dapp/pull/281))
- Add support for ppom malicious signatures in multiple networks ([#279](https://github.com/MetaMask/test-dapp/pull/279))
- Add `wallet_revokePermissions` for `eth_accounts` ([#278](https://github.com/MetaMask/test-dapp/pull/278))