### PR TITLE
Add Malformed Signatures

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1123,10 +1123,62 @@
                   Result:
                   <span id="siweResult"></span>
                 </p>
-
-
               </div>
             </div>
+          </div>
+            <div
+            class="col-xl-4 col-lg-6 col-md-12 col-sm-12 col-12 d-flex align-items-stretch"
+          >
+            <div class="card full-width">
+              <div class="card-body">
+                <h4>
+                  Malformed Signatures
+                </h4>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signInvalidType"
+                  disabled
+                >
+                Invalid Type
+                </button>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signEmptyDomain"
+                  disabled
+                >
+                Empty Domain
+                </button>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signExtraDataNotTyped"
+                  disabled
+                >
+                Extra Data not Typed
+                </button>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signInvalidPrimaryType"
+                  disabled
+                >
+                Invalid Primary Type
+                </button>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signNoPrimaryTypeDefined"
+                  disabled
+                >
+                No Primary Type Defined
+                </button>
+
+                <p class="info-text alert alert-warning">
+                  Result:
+                  <span id="signMalformedResult"></span>
+                </p>
+              </div>
           </div>
         </div>
       </section>

--- a/src/index.html
+++ b/src/index.html
@@ -1173,7 +1173,13 @@
                 >
                 No Primary Type Defined
                 </button>
-
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signInvalidVerifyingContractType"
+                  disabled
+                >
+                Invalid Verifying Contract Type
+                </button>
                 <p class="info-text alert alert-warning">
                   Result:
                   <span id="signMalformedResult"></span>

--- a/src/index.js
+++ b/src/index.js
@@ -238,6 +238,9 @@ const signInvalidPrimaryType = document.getElementById(
 const signNoPrimaryTypeDefined = document.getElementById(
   'signNoPrimaryTypeDefined',
 );
+const signInvalidVerifyingContractType = document.getElementById(
+  'signInvalidVerifyingContractType',
+);
 const signMalformedResult = document.getElementById('signMalformedResult');
 
 // Send form section
@@ -339,6 +342,7 @@ const allConnectedButtons = [
   signExtraDataNotTyped,
   signInvalidPrimaryType,
   signNoPrimaryTypeDefined,
+  signInvalidVerifyingContractType,
   eip747WatchButton,
   maliciousApprovalButton,
   maliciousSetApprovalForAll,
@@ -378,6 +382,7 @@ const initialConnectedButtons = [
   signExtraDataNotTyped,
   signInvalidPrimaryType,
   signNoPrimaryTypeDefined,
+  signInvalidVerifyingContractType,
   eip747WatchButton,
   maliciousApprovalButton,
   maliciousSetApprovalForAll,
@@ -409,6 +414,7 @@ const walletConnectButtons = [
   signExtraDataNotTyped,
   signInvalidPrimaryType,
   signNoPrimaryTypeDefined,
+  signInvalidVerifyingContractType,
   eip747WatchButton,
   maliciousApprovalButton,
   maliciousSetApprovalForAll,
@@ -2724,7 +2730,7 @@ const initializeFormElements = () => {
         verifyingContract: '0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC',
       },
       message: {
-        wallet: 'Hello, Bob!',
+        name: 'Hello, Bob!',
       },
       primaryType: 'Non-Existent',
       types: {
@@ -2801,6 +2807,43 @@ const initializeFormElements = () => {
           { name: 'name', type: 'string' },
           { name: 'wallets', type: 'address[]' },
         ],
+      },
+    };
+    try {
+      const from = accounts[0];
+      const sign = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+      signMalformedResult.innerHTML = sign;
+    } catch (err) {
+      console.error(err);
+      signMalformedResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+  /**
+   * Sign Invalid verifyingContract type
+   */
+  signInvalidVerifyingContractType.onclick = async () => {
+    const msgParams = {
+      domain: {
+        chainId: chainIdInt,
+        name: 'Seaport',
+        version: '1.5',
+        verifyingContract: 1,
+      },
+      message: {
+        name: 'Hello, Bob!',
+      },
+      primaryType: 'Wallet',
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        Wallet: [{ name: 'name', type: 'string' }],
       },
     };
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -2725,7 +2725,6 @@ const initializeFormElements = () => {
       },
       message: {
         wallet: 'Hello, Bob!',
-        extraData: 'This data is not typed!',
       },
       primaryType: 'Non-Existent',
       types: {

--- a/src/index.js
+++ b/src/index.js
@@ -228,6 +228,18 @@ const siweBadAccount = document.getElementById('siweBadAccount');
 const siweMalformed = document.getElementById('siweMalformed');
 const siweResult = document.getElementById('siweResult');
 
+// Malformed Signatues
+const signInvalidType = document.getElementById('signInvalidType');
+const signEmptyDomain = document.getElementById('signEmptyDomain');
+const signExtraDataNotTyped = document.getElementById('signExtraDataNotTyped');
+const signInvalidPrimaryType = document.getElementById(
+  'signInvalidPrimaryType',
+);
+const signNoPrimaryTypeDefined = document.getElementById(
+  'signNoPrimaryTypeDefined',
+);
+const signMalformedResult = document.getElementById('signMalformedResult');
+
 // Send form section
 const fromDiv = document.getElementById('fromInput');
 const toDiv = document.getElementById('toInput');
@@ -322,6 +334,11 @@ const allConnectedButtons = [
   siweBadDomain,
   siweBadAccount,
   siweMalformed,
+  signInvalidType,
+  signEmptyDomain,
+  signExtraDataNotTyped,
+  signInvalidPrimaryType,
+  signNoPrimaryTypeDefined,
   eip747WatchButton,
   maliciousApprovalButton,
   maliciousSetApprovalForAll,
@@ -356,6 +373,11 @@ const initialConnectedButtons = [
   siweBadDomain,
   siweBadAccount,
   siweMalformed,
+  signInvalidType,
+  signEmptyDomain,
+  signExtraDataNotTyped,
+  signInvalidPrimaryType,
+  signNoPrimaryTypeDefined,
   eip747WatchButton,
   maliciousApprovalButton,
   maliciousSetApprovalForAll,
@@ -382,6 +404,11 @@ const walletConnectButtons = [
   siweBadDomain,
   siweBadAccount,
   siweMalformed,
+  signInvalidType,
+  signEmptyDomain,
+  signExtraDataNotTyped,
+  signInvalidPrimaryType,
+  signNoPrimaryTypeDefined,
   eip747WatchButton,
   maliciousApprovalButton,
   maliciousSetApprovalForAll,
@@ -2530,6 +2557,263 @@ const initializeFormElements = () => {
     } catch (err) {
       console.error(err);
       signPermitVerifyResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  /**
+   * Sign Invalid Type
+   */
+  signInvalidType.onclick = async () => {
+    const msgParams = {
+      primaryType: 'OrderComponents',
+      domain: {
+        chainId: chainIdInt,
+        name: 'Seaport',
+        version: '1.5',
+        verifyingContract: '0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC',
+      },
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        OrderComponents: [
+          { name: 'consideration', type: 'ConsiderationItem[+' },
+        ],
+      },
+      message: {
+        consideration: [
+          {
+            itemType: '0',
+            token: '0x0000000000000000000000000000000000000000',
+            identifierOrCriteria: '0',
+            startAmount: '1950000000000000',
+            endAmount: '1950000000000000',
+            recipient: '0x0000000000000000000000000000000000000000',
+          },
+        ],
+      },
+    };
+    try {
+      const from = accounts[0];
+      const sign = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+      signMalformedResult.innerHTML = sign;
+    } catch (err) {
+      console.error(err);
+      signMalformedResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  /**
+   * Sign Empty Domain
+   */
+  signEmptyDomain.onclick = async () => {
+    const msgParams = {
+      domain: {},
+      message: {
+        contents: 'Hello, Bob!',
+        from: {
+          name: 'Cow',
+          wallets: [
+            '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+            '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+          ],
+        },
+        to: [
+          {
+            name: 'Bob',
+            wallets: [
+              '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+              '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+              '0xB0B0b0b0b0b0B000000000000000000000000000',
+            ],
+          },
+        ],
+        attachment: '0x',
+      },
+      primaryType: 'Mail',
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        Group: [
+          { name: 'name', type: 'string' },
+          { name: 'members', type: 'Person[]' },
+        ],
+        Mail: [
+          { name: 'from', type: 'Person' },
+          { name: 'to', type: 'Person[]' },
+          { name: 'contents', type: 'string' },
+          { name: 'attachment', type: 'bytes' },
+        ],
+        Person: [
+          { name: 'name', type: 'string' },
+          { name: 'wallets', type: 'address[]' },
+        ],
+      },
+    };
+    try {
+      const from = accounts[0];
+      const sign = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+      signMalformedResult.innerHTML = sign;
+    } catch (err) {
+      console.error(err);
+      signMalformedResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  /**
+   * Sign Extra Data Not Typed
+   */
+  signExtraDataNotTyped.onclick = async () => {
+    const msgParams = {
+      domain: {
+        chainId: chainIdInt,
+        name: 'Seaport',
+        version: '1.5',
+        verifyingContract: '0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC',
+      },
+      message: {
+        name: 'Hello, Bob!',
+        extraData: 'This data is not typed!',
+      },
+      primaryType: 'Wallet',
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        Wallet: [{ name: 'name', type: 'string' }],
+      },
+    };
+    try {
+      const from = accounts[0];
+      const sign = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+      signMalformedResult.innerHTML = sign;
+    } catch (err) {
+      console.error(err);
+      signMalformedResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  /**
+   * Sign Invalid Primary Type
+   */
+  signInvalidPrimaryType.onclick = async () => {
+    const msgParams = {
+      domain: {
+        chainId: chainIdInt,
+        name: 'Seaport',
+        version: '1.5',
+        verifyingContract: '0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC',
+      },
+      message: {
+        wallet: 'Hello, Bob!',
+        extraData: 'This data is not typed!',
+      },
+      primaryType: 'Non-Existent',
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        Wallet: [{ name: 'name', type: 'string' }],
+      },
+    };
+    try {
+      const from = accounts[0];
+      const sign = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+      signMalformedResult.innerHTML = sign;
+    } catch (err) {
+      console.error(err);
+      signMalformedResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  /**
+   * Sign No Primary Type Defined
+   */
+  signNoPrimaryTypeDefined.onclick = async () => {
+    const msgParams = {
+      domain: {
+        chainId: chainIdInt,
+        name: 'Seaport',
+        version: '1.5',
+        verifyingContract: '0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC',
+      },
+      message: {
+        contents: 'Hello, Bob!',
+        from: {
+          name: 'Cow',
+          wallets: [
+            '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+            '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+          ],
+        },
+        to: [
+          {
+            name: 'Bob',
+            wallets: [
+              '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+              '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+              '0xB0B0b0b0b0b0B000000000000000000000000000',
+            ],
+          },
+        ],
+      },
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        Group: [
+          { name: 'name', type: 'string' },
+          { name: 'members', type: 'Person[]' },
+        ],
+        Mail: [
+          { name: 'from', type: 'Person' },
+          { name: 'to', type: 'Person[]' },
+          { name: 'contents', type: 'string' },
+        ],
+        Person: [
+          { name: 'name', type: 'string' },
+          { name: 'wallets', type: 'address[]' },
+        ],
+      },
+    };
+    try {
+      const from = accounts[0];
+      const sign = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+      signMalformedResult.innerHTML = sign;
+    } catch (err) {
+      console.error(err);
+      signMalformedResult.innerHTML = `Error: ${err.message}`;
     }
   };
 


### PR DESCRIPTION
### Description
This PR adds different malformed typed signatures.
Note, at the moment, clicking most of them results in breaking MetaMask

This uncovers the following bugs on Extension:
- [[Bug]: Signatures - Verify 3rd party details disappears if an empty domain is passed on a Typed Signature 3 & 4](https://github.com/MetaMask/metamask-extension/issues/21011)
- [[Bug]: Signatures - MetaMask breaks with the error Invalid primary type definition](https://github.com/MetaMask/metamask-extension/issues/22899)
- [[Bug]: Signatures - MetaMask breaks with error msg.map is not a function when passing an invalid type](https://github.com/MetaMask/metamask-extension/issues/22525)
- [[Bug]: Signatures - Passing extra data not typed is added in the signature but not visible on the UI](https://github.com/MetaMask/metamask-extension/issues/22900)
- [[Bug]: Signatures - MetaMask breaks with TypeError: text.slice is not a function when passing invalid verifyingContract](https://github.com/MetaMask/metamask-extension/issues/22901)


On Mobile, the wallet does not break on any of these cases, bc there's little support to validations overall, so they need to be revised entirely.

### Screenshots


![Screenshot from 2024-02-11 12-41-10](https://github.com/MetaMask/test-dapp/assets/54408225/d52246e7-f124-4c2c-972a-031715421e63)





https://github.com/MetaMask/test-dapp/assets/54408225/4eadb46b-9deb-4e9d-b164-d72f1b0638d2




https://github.com/MetaMask/test-dapp/assets/54408225/017d5f06-8cc1-4b7e-9a91-6c14eb4d3daf



