### PR TITLE
fix: adds missing try catch for Send

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2926,19 +2926,23 @@ const initializeFormElements = () => {
    */
   sendEIP1559Batch.onclick = async () => {
     for (let i = 0; i < 10; i++) {
-      provider.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from: accounts[0],
-            to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
-            value: '0x0',
-            gasLimit: '0x5028',
-            maxFeePerGas: '0x2540be400',
-            maxPriorityFeePerGas: '0x3b9aca00',
-          },
-        ],
-      });
+      try {
+        provider.request({
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              from: accounts[0],
+              to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+              value: '0x0',
+              gasLimit: '0x5028',
+              maxFeePerGas: '0x2540be400',
+              maxPriorityFeePerGas: '0x3b9aca00',
+            },
+          ],
+        });
+      } catch (err) {
+        console.error(err);
+      }
     }
   };
 
@@ -2947,19 +2951,23 @@ const initializeFormElements = () => {
    */
   sendEIP1559Queue.onclick = async () => {
     for (let i = 0; i < 10; i++) {
-      await provider.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from: accounts[0],
-            to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
-            value: '0x0',
-            gasLimit: '0x5028',
-            maxFeePerGas: '0x2540be400',
-            maxPriorityFeePerGas: '0x3b9aca00',
-          },
-        ],
-      });
+      try {
+        await provider.request({
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              from: accounts[0],
+              to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+              value: '0x0',
+              gasLimit: '0x5028',
+              maxFeePerGas: '0x2540be400',
+              maxPriorityFeePerGas: '0x3b9aca00',
+            },
+          ],
+        });
+      } catch (err) {
+        console.error(err);
+      }
     }
   };
 


### PR DESCRIPTION
## Description
Fix missing try/catch blocks for Send Batch/Queue. This was causing to see a different behaviour between Send and Signature Requests. Thanks to @cryptotavares to point out the mistake.

The 2 issues are now closed:
- https://github.com/MetaMask/metamask-extension/issues/23225
- https://github.com/MetaMask/metamask-mobile/issues/8770

## Screenshots


https://github.com/MetaMask/test-dapp/assets/54408225/e1841e98-2b5f-4769-a055-e6979c85079a

## Manual QA
1. Trigger Queue Transactions
2. Accept one -- see next one appears
3. Accept another one -- see next one appears
4. Reject one -- see next one appears

Now do the same with Signatures, and see that the result is exactly the same.