### PR TITLE
feat: add malicious tx and signatures for sepolia

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -747,6 +747,13 @@
                   Malicious Eth Transfer
                 </button>
                 <button
+                class="btn btn-primary btn-lg btn-block mb-3"
+                id="mintERC20"
+                hidden
+              >
+                Mint ERC20
+              </button>
+                <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="maliciousERC20TransferButton"
                   disabled

--- a/src/index.js
+++ b/src/index.js
@@ -270,6 +270,7 @@ const addEthereumChain = document.getElementById('addEthereumChain');
 const switchEthereumChain = document.getElementById('switchEthereumChain');
 
 // PPOM
+const mintERC20 = document.getElementById('mintERC20');
 const maliciousApprovalButton = document.getElementById(
   'maliciousApprovalButton',
 );
@@ -361,6 +362,7 @@ const allConnectedButtons = [
   maliciousPermit,
   maliciousTradeOrder,
   maliciousSeaport,
+  mintERC20,
 ];
 
 // Buttons that are available after initially connecting an account
@@ -403,6 +405,7 @@ const initialConnectedButtons = [
   maliciousPermit,
   maliciousTradeOrder,
   maliciousSeaport,
+  mintERC20,
 ];
 
 // Buttons that are available after connecting via Wallet Connect
@@ -437,6 +440,7 @@ const walletConnectButtons = [
   maliciousPermit,
   maliciousTradeOrder,
   maliciousSeaport,
+  mintERC20,
 ];
 
 /**
@@ -655,6 +659,11 @@ const handleNewChain = (chainId) => {
 
 const handleNewNetwork = (networkId) => {
   networkDiv.innerHTML = networkId;
+  if (networkId === ('11155111' || '0xaa36a7')) {
+    mintERC20.hidden = false;
+  } else {
+    mintERC20.hidden = true;
+  }
 };
 
 const getNetworkAndChainId = async () => {
@@ -1477,6 +1486,24 @@ const initializeFormElements = () => {
   /**
    *  PPOM
    */
+
+  // Mint ERC20 in Sepolia
+  mintERC20.onclick = async () => {
+    const from = accounts[0];
+    const noPrefixedAddress = from.slice(2);
+    const result = await provider.request({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from,
+          to: '0x27A56df30bC838BCA36141E517e7b5376dea68eE',
+          value: '0x0',
+          data: `0x40c10f19000000000000000000000000${noPrefixedAddress}000000000000000000000000000000000000000000000000000000001dcd6500`,
+        },
+      ],
+    });
+    console.log(result);
+  };
 
   // Malicious ERC20 Approval
   maliciousApprovalButton.onclick = async () => {

--- a/src/onchain-sample-contracts.js
+++ b/src/onchain-sample-contracts.js
@@ -5,6 +5,7 @@ export const NETWORKS_BY_CHAIN_ID = {
   56: 'bsc',
   43114: 'avalanche',
   42161: 'arbitrum',
+  11155111: 'sepolia',
 };
 
 export const ERC20_SAMPLE_CONTRACTS = {
@@ -13,6 +14,7 @@ export const ERC20_SAMPLE_CONTRACTS = {
   bsc: '0x8965349fb649A33a30cbFDa057D8eC2C48AbE2A2',
   avalanche: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
   arbitrum: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+  sepolia: '0x27A56df30bC838BCA36141E517e7b5376dea68eE',
 };
 
 export const ERC721_SAMPLE_CONTRACTS = {
@@ -21,4 +23,5 @@ export const ERC721_SAMPLE_CONTRACTS = {
   bsc: '0xebfbfd7c41b123500fb16b71c43b400c12b08be0',
   avalanche: '0x880f7e04D722e305126F7E1efd3434A7d5b1465c',
   arbitrum: '0x8659a4876369b94515a86048fe7f99daba6b9a7d',
+  sepolia: '0xbba60aa8144579e07c6db64121b0f608ab6f0c89',
 };


### PR DESCRIPTION
## Description
This PR adds support for testing malicious transactions and signatures on Sepolia.
Note: for the ERC20 transfer, if you do not own any tokens, the validation will fail. For testing this specific case, I've added a Mint button above (only for Sepolia) which allows you to mint tokens. After minting, trying the ERC20 malicious transfer should successfully validate that as malicious.

## Screenshots


https://github.com/MetaMask/test-dapp/assets/54408225/84970827-1203-491e-8c8e-00e905d648ba



## Manual Testing
Testing malicious tx and signatures:
1. Select Sepolia
2. Try Malicious Send Eth
3. Mint some ERC2 tokens
4. Try Malicious Send ERC
5. Try Malicious Approval
6. Try Set Approval for all
7. Try all the signatures

Testing mint button
1. Select Sepolia and refresh --> see Mint button is there
2. Select another network and refresh --> see Mint button is not there