### PR TITLE
Use accounts variable instead of provider.selectedAddress

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1909,7 +1909,7 @@ const initializeFormElements = () => {
     try {
       cleartextDisplay.innerText = await provider.request({
         method: 'eth_decrypt',
-        params: [ciphertextDisplay.innerText, provider.selectedAddress],
+        params: [ciphertextDisplay.innerText, accounts[0]],
       });
     } catch (error) {
       cleartextDisplay.innerText = `Error: ${error.message}`;


### PR DESCRIPTION
`window.ethereum.selectedAddress` was recently [removed from provider](https://github.com/MetaMask/providers/pull/306) after a deprecation period. This PR replaces a reference to that property with a local value instead to fix a broken E2E spec in [extension](https://github.com/MetaMask/metamask-extension/pull/23375)