### PR TITLE
Adds transferFromTokens error to token addresses text box

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -417,6 +417,10 @@
                 >
                   Approve Tokens Without Gas
                 </button>
+
+                <p class="info-text alert alert-secondary">
+                  Token methods result: <span id="tokenMethodsResult"></span>
+                </p>
               </div>
             </div>
           </div>

--- a/src/index.js
+++ b/src/index.js
@@ -1767,15 +1767,19 @@ const initializeFormElements = () => {
   };
 
   transferFromTokens.onclick = async () => {
-    const result = await hstContract.transferFrom(
-      transferFromSenderInput.value,
-      transferFromRecipientInput.value,
-      decimalUnitsInput.value === '0'
-        ? 1
-        : `${1.5 * 10 ** decimalUnitsInput.value}`,
-      { from: accounts[0] },
-    );
-    console.log('result', result);
+    try {
+      const result = await hstContract.transferFrom(
+        transferFromSenderInput.value,
+        transferFromRecipientInput.value,
+        decimalUnitsInput.value === '0'
+          ? 1
+          : `${1.5 * 10 ** decimalUnitsInput.value}`,
+        { from: accounts[0] },
+      );
+      console.log('result', result);
+    } catch (error) {
+      tokenAddresses.innerHTML = error.message;
+    }
   };
 
   transferTokensWithoutGas.onclick = async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -174,6 +174,8 @@ const approveTokensWithoutGas = document.getElementById(
   'approveTokensWithoutGas',
 );
 
+const tokenMethodsResult = document.getElementById('tokenMethodsResult');
+
 // Encrypt / Decrypt Section
 const getEncryptionKeyButton = document.getElementById(
   'getEncryptionKeyButton',
@@ -920,6 +922,7 @@ const clearDisplayElements = () => {
   cleartextDisplay.innerText = '';
   batchTransferTokenIds.value = '';
   batchTransferTokenAmounts.value = '';
+  tokenMethodsResult.value = '';
 };
 
 const updateOnboardElements = () => {
@@ -1777,8 +1780,9 @@ const initializeFormElements = () => {
         { from: accounts[0] },
       );
       console.log('result', result);
+      tokenMethodsResult.innerHTML = result;
     } catch (error) {
-      tokenAddresses.innerHTML = error.message;
+      tokenMethodsResult.innerHTML = error.message;
     }
   };
 


### PR DESCRIPTION
As part of [#2224](https://github.com/MetaMask/MetaMask-planning/issues/2224), we need to have a way to test whether the token allowance to transfer tokens is exceeded or not. This change shows the error message on the token addresses text box so that it can be asserted against in e2e tests.

<img width="1312" alt="Screenshot 2024-03-18 at 16 52 59" src="https://github.com/MetaMask/test-dapp/assets/13814744/82b0fd8a-ceab-49f4-ac5b-3fdc5888acd1">
