### PR TITLE
fix: Fix network status field

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -767,7 +767,7 @@ const closeProvider = () => {
   if (isMetaMaskInstalled()) {
     provider.removeListener('chainChanged', handleNewChain);
     provider.removeListener('chainChanged', handleEIP1559Support);
-    provider.removeListener('chainChanged', handleNewNetwork);
+    provider.removeListener('networkChanged', handleNewNetwork);
     provider.removeListener('accountsChanged', handleNewAccounts);
     provider.removeListener('accountsChanged', handleEIP1559Support);
   }
@@ -785,7 +785,7 @@ const initializeProvider = async () => {
 
     provider.on('chainChanged', handleNewChain);
     provider.on('chainChanged', handleEIP1559Support);
-    provider.on('chainChanged', handleNewNetwork);
+    provider.on('networkChanged', handleNewNetwork);
     provider.on('accountsChanged', handleNewAccounts);
     provider.on('accountsChanged', handleEIP1559Support);
 


### PR DESCRIPTION
The network status field would show the `networkId` on load (in decimal), but after switching chains it would show the `chainId` (in hex). It now shows the `networkId` in all cases.

This means re-introducing the deprecated `networkChanged` event listener, but this listener is still something we want to be able to test.