### PR TITLE
Release candidate v8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [8.4.0]
+### Added
+- Add Malformed Transactions ([#295](https://github.com/MetaMask/test-dapp/pull/295))
+- Adds transferFromTokens error to token addresses text box ([#304](https://github.com/MetaMask/test-dapp/pull/304))
+- Add Increase Token Allowance btn ([#302](https://github.com/MetaMask/test-dapp/pull/302))
+
 ## [8.3.0]
 ### Fixed
 - Replace deprecated `window.ethereum.selectedAddress` property with local account value ([#300](https://github.com/MetaMask/test-dapp/pull/300))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
-[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v8.3.0...HEAD
+[8.4.0]: https://github.com/MetaMask/test-dapp/compare/v8.3.0...release-v8.4.0
 [8.3.0]: https://github.com/MetaMask/test-dapp/compare/v8.2.0...v8.3.0
 [8.2.0]: https://github.com/MetaMask/test-dapp/compare/v8.1.0...v8.2.0
 [8.1.0]: https://github.com/MetaMask/test-dapp/compare/v8.0.0...v8.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 18.0.0"


### PR DESCRIPTION
This is the release candidate for v8.4.0.
   **Added:**
- Add Malformed Transactions ([#295](https://github.com/MetaMask/test-dapp/pull/295))
- Adds transferFromTokens error to token addresses text box ([#304](https://github.com/MetaMask/test-dapp/pull/304))
- Add Increase Token Allowance btn ([#302](https://github.com/MetaMask/test-dapp/pull/302))