### PR TITLE
Release candidate v8.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
-[8.4.0]: https://github.com/MetaMask/test-dapp/compare/v8.3.0...release-v8.4.0
+[8.5.0]: https://github.com/MetaMask/test-dapp/compare/v8.4.0...release-v8.5.0
+[8.4.0]: https://github.com/MetaMask/test-dapp/compare/v8.3.0...v8.4.0
 [8.3.0]: https://github.com/MetaMask/test-dapp/compare/v8.2.0...v8.3.0
 [8.2.0]: https://github.com/MetaMask/test-dapp/compare/v8.1.0...v8.2.0
 [8.1.0]: https://github.com/MetaMask/test-dapp/compare/v8.0.0...v8.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
-[8.5.0]: https://github.com/MetaMask/test-dapp/compare/v8.4.0...release-v8.5.0
+[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v8.5.0...HEAD
+[8.5.0]: https://github.com/MetaMask/test-dapp/compare/v8.4.0...v8.5.0
 [8.4.0]: https://github.com/MetaMask/test-dapp/compare/v8.3.0...v8.4.0
 [8.3.0]: https://github.com/MetaMask/test-dapp/compare/v8.2.0...v8.3.0
 [8.2.0]: https://github.com/MetaMask/test-dapp/compare/v8.1.0...v8.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [8.5.0]
+### Added
+- Add Base network support ([#2310](https://github.com/MetaMask/test-dapp/pull/310))
+
 ## [8.4.0]
 ### Added
 - Add Malformed Transactions ([#295](https://github.com/MetaMask/test-dapp/pull/295))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 18.0.0"


### PR DESCRIPTION
This is the release candidate for v8.5.0.
(We update the version earlier than usual to provide an opportunity for everyone to test on the Base chain.)

**Added:**
- Add Base network support [#310](https://github.com/MetaMask/test-dapp/pull/310)

