### PR TITLE
feat: add get allowance support for ERC20 tokens

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -354,7 +354,7 @@
                 >
                   Transfer Tokens
                 </button>
-
+                <hr />
                 <div class="form-group">
                   <label>Approve to Address</label>
                   <input
@@ -380,6 +380,33 @@
                   Increase Token Allowance
                 </button>
 
+                <hr />
+                <div class="form-group">
+                  <label>Owner Address</label>
+                  <input
+                    class="form-control"
+                    id="allowanceOwner"
+                  />
+                </div>
+
+                <div class="form-group">
+                  <label>Spender Address</label>
+                  <input
+                    class="form-control"
+                    id="allowanceSpender"
+                  />
+                </div>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="getAllowance"
+                  disabled
+                >
+                  Get Allowance
+                </button>
+                <p class="info-text alert alert-secondary">
+                  Allowance amount: <span id="allowanceAmount"></span>
+                </p>
+                <hr />
                 <div class="form-group">
                   <label>Transfer From</label>
                   <input
@@ -402,6 +429,7 @@
                 >
                   Transfer From Tokens
                 </button>
+                <hr />
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="transferTokensWithoutGas"

--- a/src/index.html
+++ b/src/index.html
@@ -404,7 +404,7 @@
                   Get Allowance
                 </button>
                 <p class="info-text alert alert-secondary">
-                  Allowance amount: <span id="allowanceAmount"></span>
+                  Allowance amount: <span id="allowanceAmountResult"></span>
                 </p>
                 <hr />
                 <div class="form-group">

--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,11 @@ const approveTokens = document.getElementById('approveTokens');
 const increaseTokenAllowance = document.getElementById(
   'increaseTokenAllowance',
 );
+const allowanceOwnerInput = document.getElementById('allowanceOwner');
+const allowanceSpenderInput = document.getElementById('allowanceSpender');
+
+const allowanceAmount = document.getElementById('allowanceAmount');
+const getAllowance = document.getElementById('getAllowance');
 const transferTokensWithoutGas = document.getElementById(
   'transferTokensWithoutGas',
 );
@@ -345,6 +350,10 @@ const allConnectedButtons = [
   transferFromTokens,
   approveTokens,
   increaseTokenAllowance,
+  allowanceOwnerInput,
+  allowanceSpenderInput,
+  getAllowance,
+  allowanceAmount,
   transferFromRecipientInput,
   transferFromSenderInput,
   transferTokensWithoutGas,
@@ -1068,6 +1077,10 @@ const updateContractElements = () => {
     transferFromTokens.disabled = false;
     approveTokens.disabled = false;
     increaseTokenAllowance.disabled = false;
+    allowanceSpenderInput.disabled = false;
+    allowanceOwnerInput.disabled = false;
+    getAllowance.disabled = false;
+    allowanceAmount.disabled = false;
     transferTokensWithoutGas.disabled = false;
     approveTokensWithoutGas.disabled = false;
     transferFromSenderInput.disabled = false;
@@ -1748,6 +1761,10 @@ const initializeFormElements = () => {
     transferFromTokens.disabled = false;
     approveTokens.disabled = false;
     increaseTokenAllowance.disabled = false;
+    allowanceOwnerInput.disabled = false;
+    allowanceSpenderInput.disabled = false;
+    allowanceAmount.disabled = false;
+    getAllowance.disabled = false;
     transferTokensWithoutGas.disabled = false;
     approveTokensWithoutGas.disabled = false;
     approveTokensToInput.disabled = false;
@@ -1805,6 +1822,15 @@ const initializeFormElements = () => {
       { from: accounts[0] },
     );
     console.log('result', result);
+  };
+
+  getAllowance.onclick = async () => {
+    const result = await hstContract.allowance(
+      allowanceOwnerInput.value,
+      allowanceSpenderInput.value,
+      { from: accounts[0] },
+    );
+    allowanceAmount.innerHTML = result.toNumber();
   };
 
   transferFromTokens.onclick = async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ const increaseTokenAllowance = document.getElementById(
 const allowanceOwnerInput = document.getElementById('allowanceOwner');
 const allowanceSpenderInput = document.getElementById('allowanceSpender');
 
-const allowanceAmount = document.getElementById('allowanceAmount');
+const allowanceAmountResult = document.getElementById('allowanceAmountResult');
 const getAllowance = document.getElementById('getAllowance');
 const transferTokensWithoutGas = document.getElementById(
   'transferTokensWithoutGas',
@@ -353,7 +353,7 @@ const allConnectedButtons = [
   allowanceOwnerInput,
   allowanceSpenderInput,
   getAllowance,
-  allowanceAmount,
+  allowanceAmountResult,
   transferFromRecipientInput,
   transferFromSenderInput,
   transferTokensWithoutGas,
@@ -1080,7 +1080,7 @@ const updateContractElements = () => {
     allowanceSpenderInput.disabled = false;
     allowanceOwnerInput.disabled = false;
     getAllowance.disabled = false;
-    allowanceAmount.disabled = false;
+    allowanceAmountResult.disabled = false;
     transferTokensWithoutGas.disabled = false;
     approveTokensWithoutGas.disabled = false;
     transferFromSenderInput.disabled = false;
@@ -1763,7 +1763,7 @@ const initializeFormElements = () => {
     increaseTokenAllowance.disabled = false;
     allowanceOwnerInput.disabled = false;
     allowanceSpenderInput.disabled = false;
-    allowanceAmount.disabled = false;
+    allowanceAmountResult.disabled = false;
     getAllowance.disabled = false;
     transferTokensWithoutGas.disabled = false;
     approveTokensWithoutGas.disabled = false;
@@ -1830,7 +1830,10 @@ const initializeFormElements = () => {
       allowanceSpenderInput.value,
       { from: accounts[0] },
     );
-    allowanceAmount.innerHTML = result.toNumber();
+    const allowance = result.toNumber() / 10 ** decimalUnitsInput.value;
+    allowanceAmountResult.innerHTML = allowance.toFixed(
+      decimalUnitsInput.value,
+    );
   };
 
   transferFromTokens.onclick = async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,6 @@ const increaseTokenAllowance = document.getElementById(
 );
 const allowanceOwnerInput = document.getElementById('allowanceOwner');
 const allowanceSpenderInput = document.getElementById('allowanceSpender');
-
 const allowanceAmountResult = document.getElementById('allowanceAmountResult');
 const getAllowance = document.getElementById('getAllowance');
 const transferTokensWithoutGas = document.getElementById(
@@ -352,8 +351,8 @@ const allConnectedButtons = [
   increaseTokenAllowance,
   allowanceOwnerInput,
   allowanceSpenderInput,
-  getAllowance,
   allowanceAmountResult,
+  getAllowance,
   transferFromRecipientInput,
   transferFromSenderInput,
   transferTokensWithoutGas,
@@ -1077,10 +1076,10 @@ const updateContractElements = () => {
     transferFromTokens.disabled = false;
     approveTokens.disabled = false;
     increaseTokenAllowance.disabled = false;
-    allowanceSpenderInput.disabled = false;
     allowanceOwnerInput.disabled = false;
-    getAllowance.disabled = false;
+    allowanceSpenderInput.disabled = false;
     allowanceAmountResult.disabled = false;
+    getAllowance.disabled = false;
     transferTokensWithoutGas.disabled = false;
     approveTokensWithoutGas.disabled = false;
     transferFromSenderInput.disabled = false;


### PR DESCRIPTION
## Description
This PR adds support for querying the `allowance(address owner, address spender) → uint256` function for ERC20 tokens.
This will enable testing more effectively the Approve and Increase Allowance functionalities.

## Screenshots
![Screenshot from 2024-04-08 12-44-11](https://github.com/MetaMask/test-dapp/assets/54408225/c52accf9-9eb0-4187-aed9-fb0f9a36d4b7)


https://github.com/MetaMask/test-dapp/assets/54408225/4f8d18ba-f02f-431b-bc8e-7f1f5fdb7e41





## Manual Testing Steps
1. Deploy an ERC20 token contract
2. Add owner and spender addresses
3. Click get allowance
4. Perform an approve or increase allowance to the same spender and owner
5. Click get allowance
6. See how the amount changed