### PR TITLE
feat: add deeplinks for Send Eth, Send ERC20 and Approve ERC20

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -222,7 +222,6 @@
                 </button>
                 <a
                   id="sendDeeplinkButton"
-                  href="https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0"
                 >
                   <button
                     class="btn btn-warning btn-lg btn-block mb-3"

--- a/src/index.html
+++ b/src/index.html
@@ -224,7 +224,7 @@
                   id="sendDeeplinkButton"
                 >
                   <button
-                    class="btn btn-warning btn-lg btn-block mb-3"
+                    class="btn btn-warning btn-lg btn-block mb-3 text-dark"
                   >
                   (Mobile) Send with Deeplink
                   </button>
@@ -368,7 +368,7 @@
                   id="transferTokensDeeplink"
                 >
                   <button
-                  class="btn btn-warning btn-lg btn-block mb-3"
+                  class="btn btn-warning btn-lg btn-block mb-3 text-dark"
                   >
                   (Mobile) Transfer Tokens with Deeplink
                   </button>
@@ -395,7 +395,7 @@
                   id="approveTokensDeeplink"
                 >
                   <button
-                  class="btn btn-warning btn-lg btn-block mb-3"
+                  class="btn btn-warning btn-lg btn-block mb-3 text-dark"
                   >
                   (Mobile) Approve Tokens with Deeplink
                   </button>

--- a/src/index.html
+++ b/src/index.html
@@ -220,6 +220,13 @@
                 >
                   Send EIP 1559 Transaction
                 </button>
+                <button
+                  class="btn btn-warning btn-lg btn-block mb-3"
+                  id="sendDeeplinkButton"
+                  src="https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0"
+                >
+                  Send with Deeplink
+                </button>
                 <hr />
                 <h4 class="card-title">
                   Piggy bank contract
@@ -355,6 +362,14 @@
                   Transfer Tokens
                 </button>
 
+                <button
+                  class="btn btn-warning btn-lg btn-block mb-3"
+                  id="transferTokensDeeplink"
+                  src="https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0"
+                  disabled
+                >
+                  Transfer Tokens with Deeplink
+                </button>
                 <div class="form-group">
                   <label>Approve to Address</label>
                   <input
@@ -371,7 +386,14 @@
                 >
                   Approve Tokens
                 </button>
-
+                <button
+                  class="btn btn-warning btn-lg btn-block mb-3"
+                  id="approveTokensDeeplink"
+                  src="https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0"
+                  disabled
+                >
+                  Approve Tokens with Deeplink
+                </button>
                 <div class="form-group">
                   <label>Transfer From</label>
                   <input

--- a/src/index.html
+++ b/src/index.html
@@ -220,13 +220,16 @@
                 >
                   Send EIP 1559 Transaction
                 </button>
-                <button
-                  class="btn btn-warning btn-lg btn-block mb-3"
+                <a
                   id="sendDeeplinkButton"
-                  src="https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0"
+                  href="https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0"
                 >
-                  Send with Deeplink
-                </button>
+                  <button
+                    class="btn btn-warning btn-lg btn-block mb-3"
+                  >
+                  (Mobile) Send with Deeplink
+                  </button>
+                </a>
                 <hr />
                 <h4 class="card-title">
                   Piggy bank contract
@@ -362,14 +365,16 @@
                   Transfer Tokens
                 </button>
 
-                <button
-                  class="btn btn-warning btn-lg btn-block mb-3"
+                <a 
                   id="transferTokensDeeplink"
-                  src="https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0"
-                  disabled
                 >
-                  Transfer Tokens with Deeplink
-                </button>
+                  <button
+                  class="btn btn-warning btn-lg btn-block mb-3"
+                  >
+                  (Mobile) Transfer Tokens with Deeplink
+                  </button>
+                </a>
+
                 <hr />
                 <div class="form-group">
                   <label>Approve to Address</label>
@@ -387,14 +392,15 @@
                 >
                   Approve Tokens
                 </button>
-                <button
-                  class="btn btn-warning btn-lg btn-block mb-3"
+                <a
                   id="approveTokensDeeplink"
-                  src="https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0"
-                  disabled
                 >
-                  Approve Tokens with Deeplink
-                </button>
+                  <button
+                  class="btn btn-warning btn-lg btn-block mb-3"
+                  >
+                  (Mobile) Approve Tokens with Deeplink
+                  </button>
+                </a>
 
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,11 @@ if (!ethers.utils.isAddress(deployedContractAddress)) {
   deployedContractAddress = '';
 }
 
+let tokenDecimals = urlSearchParams.get('decimals');
+if (!tokenDecimals) {
+  tokenDecimals = '18';
+}
+
 const scrollTo = urlSearchParams.get('scrollTo');
 
 /**
@@ -310,6 +315,12 @@ const maliciousSeaport = document.getElementById('maliciousSeaport');
 const maliciousSetApprovalForAll = document.getElementById(
   'maliciousSetApprovalForAll',
 );
+
+// Deeplinks
+const transferTokensDeeplink = document.getElementById(
+  'transferTokensDeeplink',
+);
+const approveTokensDeeplink = document.getElementById('approveTokensDeeplink');
 
 // Buttons that require connecting an account
 const allConnectedButtons = [
@@ -866,8 +877,6 @@ const initializeContracts = () => {
         hstAbi,
         ethersProvider.getSigner(),
       );
-      transferTokensDeeplink.src =
-        `https://metamask.app.link/send/${deployedContractAddress}/transfer?address=0x2f318C334780961FB129D2a6c30D0763d9a5C970&uint256=4e18`
       piggybankContract = new ethers.Contract(
         deployedContractAddress,
         piggybankAbi,
@@ -1075,7 +1084,6 @@ const updateContractElements = () => {
     tokenAddresses.innerHTML = hstContract ? hstContract.address : '';
     watchAssets.disabled = false;
     transferTokens.disabled = false;
-    transferTokensDeeplink.disabled = false;
     transferFromTokens.disabled = false;
     approveTokens.disabled = false;
     increaseTokenAllowance.disabled = false;
@@ -3273,6 +3281,11 @@ const initializeFormElements = () => {
   useWindowProviderButton.onclick = setActiveProviderDetailWindowEthereum;
 };
 
+const setDeeplinks = () => {
+  transferTokensDeeplink.href = `https://metamask.app.link/send/${deployedContractAddress}/transfer?address=0x2f318C334780961FB129D2a6c30D0763d9a5C970&uint256=4e${tokenDecimals}`;
+  approveTokensDeeplink.href = `https://metamask.app.link/approve/${deployedContractAddress}/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=3e${tokenDecimals}`;
+};
+
 /**
  * Entrypoint
  */
@@ -3281,6 +3294,7 @@ const initialize = async () => {
   setActiveProviderDetailWindowEthereum();
   detectEip6963();
   initializeFormElements();
+  setDeeplinks();
 };
 
 window.addEventListener('load', initialize);

--- a/src/index.js
+++ b/src/index.js
@@ -317,6 +317,7 @@ const maliciousSetApprovalForAll = document.getElementById(
 );
 
 // Deeplinks
+const sendDeeplinkButton = document.getElementById('sendDeeplinkButton');
 const transferTokensDeeplink = document.getElementById(
   'transferTokensDeeplink',
 );
@@ -3282,6 +3283,8 @@ const initializeFormElements = () => {
 };
 
 const setDeeplinks = () => {
+  sendDeeplinkButton.href =
+    'https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0';
   transferTokensDeeplink.href = `https://metamask.app.link/send/${deployedContractAddress}/transfer?address=0x2f318C334780961FB129D2a6c30D0763d9a5C970&uint256=4e${tokenDecimals}`;
   approveTokensDeeplink.href = `https://metamask.app.link/approve/${deployedContractAddress}/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=3e${tokenDecimals}`;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -814,6 +814,8 @@ const initializeContracts = () => {
         hstAbi,
         ethersProvider.getSigner(),
       );
+      transferTokensDeeplink.src =
+        `https://metamask.app.link/send/${deployedContractAddress}/transfer?address=0x2f318C334780961FB129D2a6c30D0763d9a5C970&uint256=4e18`
       piggybankContract = new ethers.Contract(
         deployedContractAddress,
         piggybankAbi,
@@ -1020,6 +1022,7 @@ const updateContractElements = () => {
     tokenAddresses.innerHTML = hstContract ? hstContract.address : '';
     watchAssets.disabled = false;
     transferTokens.disabled = false;
+    transferTokensDeeplink.disabled = false;
     transferFromTokens.disabled = false;
     approveTokens.disabled = false;
     transferTokensWithoutGas.disabled = false;


### PR DESCRIPTION
## Description
This PR adds support to Deeplinks in the test dapp. This will allows us to automate e2e tests around the feature. Specifically,
- Adds Simple Send Eth for deeplinks
- Adds ERC20 transfer. For this, we need to pass the contract address and the decimals in the URL. Notice for this functionality we'll access it from the browser (outside the wallet), that's why we need to pre-deploy a contract, in order to use it, if we want to have assets.
- Adds ERC20 approve. For this, we need to pass the contract address and the decimals in the URL. Notice for this functionality we'll access it from the browser (outside the wallet), that's why we need to pre-deploy a contract, in order to use it, if we want to have assets.

## Screenshots

![Screenshot from 2024-04-08 20-03-33](https://github.com/MetaMask/test-dapp/assets/54408225/b5f5904c-7ed0-42b2-8f1a-d5ca98cf668a)



https://github.com/MetaMask/test-dapp/assets/54408225/723e133e-9cb6-4422-b4c1-764e1c632c08




## Manual QA
1. Build the test dapp locally
2. With the Extension/Mobile test dapp: deploy an ERC20 token
3. Copy the address the the decimals (default is 4)
4. Now, go to the Mobile Browser (outside the MetaMask wallet)
5. Add this URL: `http://localhost:9011/?contract=0x35e22143f85CD31F5319Ae4295B36F396bF27f78&decimals=4` but change the contract address and decimals for the one you deployed
6. Click Send Eth --open MM and proceed with the tx
7. Go back to the browser
8. Click Transfer Tokens -- open MM and proceed with the tx
9. Go back to the browser
10. Click Approve Tokens -- open MM and proceed with the tx