### PR TITLE
Release Candidate v8.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.6.0]
 ### Added
 - feat: add deeplinks for Send Eth, Send ERC20 and Approve ERC20 ([#313](https://github.com/MetaMask/test-dapp/pull/313))
-- update NFT contract ([#315](https://github.com/MetaMask/test-dapp/pull/315))
 - feat: add get allowance support for ERC20 tokens ([#312](https://github.com/MetaMask/test-dapp/pull/312))
+### Fixed
 - fix: Fix network status field ([#306](https://github.com/MetaMask/test-dapp/pull/306))
+- update NFT contract ([#315](https://github.com/MetaMask/test-dapp/pull/315))
 
 ## [8.5.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add get allowance support for ERC20 tokens ([#312](https://github.com/MetaMask/test-dapp/pull/312))
 ### Fixed
 - Fix network status field ([#306](https://github.com/MetaMask/test-dapp/pull/306))
-- Update NFT contract ([#315](https://github.com/MetaMask/test-dapp/pull/315))
+- Fix NFT contract address for Base network ([#315](https://github.com/MetaMask/test-dapp/pull/315))
 
 ## [8.5.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [8.6.0]
+### Added
+- feat: add deeplinks for Send Eth, Send ERC20 and Approve ERC20 ([#313](https://github.com/MetaMask/test-dapp/pull/313))
+- update NFT contract ([#315](https://github.com/MetaMask/test-dapp/pull/315))
+- feat: add get allowance support for ERC20 tokens ([#312](https://github.com/MetaMask/test-dapp/pull/312))
+- fix: Fix network status field ([#306](https://github.com/MetaMask/test-dapp/pull/306))
+
 ## [8.5.0]
 ### Added
 - Add Base network support ([#2310](https://github.com/MetaMask/test-dapp/pull/310))
@@ -161,7 +168,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
-[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v8.5.0...HEAD
+[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v8.6.0...HEAD
+[8.6.0]: https://github.com/MetaMask/test-dapp/compare/v8.5.0...v8.6.0
 [8.5.0]: https://github.com/MetaMask/test-dapp/compare/v8.4.0...v8.5.0
 [8.4.0]: https://github.com/MetaMask/test-dapp/compare/v8.3.0...v8.4.0
 [8.3.0]: https://github.com/MetaMask/test-dapp/compare/v8.2.0...v8.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## [8.6.0]
 ### Added
-- feat: add deeplinks for Send Eth, Send ERC20 and Approve ERC20 ([#313](https://github.com/MetaMask/test-dapp/pull/313))
-- feat: add get allowance support for ERC20 tokens ([#312](https://github.com/MetaMask/test-dapp/pull/312))
+- Add deeplinks for Send Eth, Send ERC20 and Approve ERC20 ([#313](https://github.com/MetaMask/test-dapp/pull/313))
+- Add get allowance support for ERC20 tokens ([#312](https://github.com/MetaMask/test-dapp/pull/312))
 ### Fixed
-- fix: Fix network status field ([#306](https://github.com/MetaMask/test-dapp/pull/306))
-- update NFT contract ([#315](https://github.com/MetaMask/test-dapp/pull/315))
+- Fix network status field ([#306](https://github.com/MetaMask/test-dapp/pull/306))
+- Update NFT contract ([#315](https://github.com/MetaMask/test-dapp/pull/315))
 
 ## [8.5.0]
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 18.0.0"


### PR DESCRIPTION
This is the release candidate for v8.6.0.

Added:
- add deeplinks for Send Eth, Send ERC20 and Approve ERC20 ([#313](https://github.com/MetaMask/test-dapp/pull/313))
- update Base NFT contract address ([#315](https://github.com/MetaMask/test-dapp/pull/315))
- feat: add get allowance support for ERC20 tokens ([#312](https://github.com/MetaMask/test-dapp/pull/312))
- Fix network status field ([#306](https://github.com/MetaMask/test-dapp/pull/306))