### PR TITLE
fix: make signPermit EIP712Domain following EIP-712

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2573,8 +2573,8 @@ const initializeFormElements = () => {
     const EIP712Domain = [
       { name: 'name', type: 'string' },
       { name: 'version', type: 'string' },
-      { name: 'verifyingContract', type: 'address' },
       { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
     ];
 
     const permit = {
@@ -2657,8 +2657,8 @@ const initializeFormElements = () => {
     const EIP712Domain = [
       { name: 'name', type: 'string' },
       { name: 'version', type: 'string' },
-      { name: 'verifyingContract', type: 'address' },
       { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
     ];
 
     const permit = {


### PR DESCRIPTION
Hi, I found the the `signPermit` test case is not following EIP-712 strictly so that Keystone won't able to pass this test case.

ref: https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator:~:text=The%20EIP712Domain%20fields%20should%20be%20the%20order%20as%20above%2C%20skipping%20any%20absent%20fields.%20Future%20field%20additions%20must%20be%20in%20alphabetical%20order%20and%20come%20after%20the%20above%20fields.%20User%2Dagents%20should%20accept%20fields%20in%20any%20order%20as%20specified%20by%20the%20EIPT712Domain%20type