### PR TITLE
feat: Add support for Send EIP1559 tx without suggested gas values

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -220,6 +220,14 @@
                 >
                   Send EIP 1559 Transaction
                 </button>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="sendEIP1559WithoutGasButton"
+                  disabled
+                  hidden
+                >
+                  Send EIP 1559 Without Gas
+                </button>
                 <a
                   id="sendDeeplinkButton"
                 >

--- a/src/index.js
+++ b/src/index.js
@@ -152,6 +152,9 @@ const eip747Status = document.getElementById('eip747Status');
 // Send Eth Section
 const sendButton = document.getElementById('sendButton');
 const sendEIP1559Button = document.getElementById('sendEIP1559Button');
+const sendEIP1559WithoutGasButton = document.getElementById(
+  'sendEIP1559WithoutGasButton',
+);
 
 // Send Tokens Section
 const decimalUnitsInput = document.getElementById('tokenDecimals');
@@ -755,6 +758,8 @@ const handleEIP1559Support = async () => {
   if (supported && Array.isArray(accounts) && accounts.length >= 1) {
     sendEIP1559Button.disabled = false;
     sendEIP1559Button.hidden = false;
+    sendEIP1559WithoutGasButton.disabled = false;
+    sendEIP1559WithoutGasButton.hidden = false;
     sendWithInvalidMaxFeePerGas.disabled = false;
     sendWithInvalidMaxFeePerGas.hidden = false;
     sendEIP1559Batch.disabled = false;
@@ -767,6 +772,8 @@ const handleEIP1559Support = async () => {
   } else {
     sendEIP1559Button.disabled = true;
     sendEIP1559Button.hidden = true;
+    sendEIP1559WithoutGasButton.disabled = true;
+    sendEIP1559WithoutGasButton.hidden = true;
     sendEIP1559Batch.disabled = true;
     sendEIP1559Batch.hidden = true;
     sendEIP1559Queue.disabled = true;
@@ -1728,6 +1735,20 @@ const initializeFormElements = () => {
           gasLimit: '0x5028',
           maxFeePerGas: '0x2540be400',
           maxPriorityFeePerGas: '0x3b9aca00',
+        },
+      ],
+    });
+    console.log(result);
+  };
+
+  sendEIP1559WithoutGasButton.onclick = async () => {
+    const result = await provider.request({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: accounts[0],
+          to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+          value: '0x0',
         },
       ],
     });


### PR DESCRIPTION
## Description
This PR adds support for SendEIP1559 transactions without suggested gas values.
This adds another flow for testing and fixes the issues encountered in certain network conditions, when gas values are high and the dapp suggested values are off, making tx's fail.
More context [here](https://consensys.slack.com/archives/C029JG63136/p1713175732692349?thread_ts=1712935151.911099&cid=C029JG63136).

## Screenshots

![Screenshot from 2024-04-16 14-15-29](https://github.com/MetaMask/test-dapp/assets/54408225/be9f8453-5053-4417-9bfb-5a32d554128a)


https://github.com/MetaMask/test-dapp/assets/54408225/104b2d72-e82e-4a69-966d-532fe2e3ac75

## Manual Testing Steps

1. Connect to the test dapp
2. Trigger a SendEIP1559 Without suggested gas tx
3. See gas is set to Market, instead of Dapp Suggested
