### PR TITLE
fix: queue malicious tx address

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3282,7 +3282,7 @@ const initializeFormElements = () => {
           params: [
             {
               from: accounts[0],
-              to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+              to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
               value: '0x0',
               gasLimit: '0x5028',
               maxFeePerGas: '0x2540be400',


### PR DESCRIPTION
### Description
This changes the recipient address for the Queue transactions, to a malicious one, so queue tx's are flagged as malicious.
Context: this was identified by @sleepytanya in this issue https://github.com/MetaMask/metamask-mobile/issues/9272

### Screenshots

https://github.com/MetaMask/test-dapp/assets/54408225/babfc800-cf31-4388-b0a4-7c63c6e8fa43

