### PR TITLE
feat: add malicious deeplinks, bypasses and reorg

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -814,8 +814,10 @@
             <div class="card full-width">
               <div class="card-body">
                 <h4 class="card-title">
-                  PPOM
+                  PPOM - Malicious Transactions and Signatures
                 </h4>
+                <p>We know we are vulnerable if any of these Transactions/Signatures are not flagged as Malicious</p>
+                <h5>Transactions</h5>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="maliciousRawEthButton"
@@ -834,6 +836,7 @@
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="maliciousERC20TransferButton"
                   disabled
+                  title="This will only be flagged if you have some ERC20 balance"
                 >
                   Malicious ERC20 Transfer (USDC)
                 </button>
@@ -851,6 +854,7 @@
                 >
                   Malicious Set Approval For All
                 </button>
+                <h5>Signatures</h5>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="maliciousPermit"
@@ -881,9 +885,10 @@
             <div class="card full-width">
               <div class="card-body">
                 <h4>
-                  Batch of 10 Malicious Transactions
+                  PPOM - Malicious Batching and Queueing
                 </h4>
-          
+                <p>We know we are vulnerable if any of these Transactions/Signatures are not flagged as Malicious</p>
+                <h5>Transactions</h5>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="sendEIP1559Batch"
@@ -891,10 +896,7 @@
                 >
                   Send Eth Malicious x10 Batch
                 </button>
-                <h4>
-                  Queue of 10 Malicious Transactions
-                </h4>
-          
+
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="sendEIP1559Queue"
@@ -902,10 +904,8 @@
                 >
                   Send Eth Malicious x10 Queue
                 </button>
-                <h4>
-                  Batch of 10 Malicious Signatures
-                </h4>
 
+                <h5>Signatures</h5>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="signTypedDataV4Batch"
@@ -914,16 +914,84 @@
                   Sign Malicious x10 Batch
                 </button>
 
-                <h4>
-                  Queue of 10 Malicious Signatures
-                </h4>
-
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="signTypedDataV4Queue"
                   disabled
                 >
                   Sign Malicious x10 Queue
+                </button>
+                <hr />
+                <h4>PPOM - Malicious Deeplinks</h4>
+                <a
+                  id="maliciousSendEthWithDeeplink"
+                >
+                  <button
+                    class="btn btn-warning btn-lg btn-block mb-3 text-dark"
+                  >
+                  (Mobile) Malicious Eth Transfer With Deeplink
+                  </button>
+                </a>
+                <a
+                  id="maliciousTransferERC20WithDeeplink"
+                >
+                  <button
+                    class="btn btn-warning btn-lg btn-block mb-3 text-dark"
+                  >
+                  (Mobile) Malicious ERC20 Transfer With Deeplink
+                  </button>
+                </a>
+                <a
+                id="maliciousApproveERC20WithDeeplink"
+                >
+                  <button
+                    class="btn btn-warning btn-lg btn-block mb-3 text-dark"
+                  >
+                  (Mobile) Malicious ERC20 Approval With Deeplink
+                  </button>
+                </a>
+              </div>
+            </div>
+          </div>
+          <div
+            class="col-xl-4 col-lg-6 col-md-12 col-sm-12 col-12 d-flex align-items-stretch"
+          >
+            <div class="card full-width">
+              <div class="card-body">
+                <h4>
+                  PPOM - Malicious Warning Bypasses
+                </h4>
+                <p>We know we are vulnerable if any of these Transactions/Signatures are not flagged as Malicious</p>
+                <h5>Transactions</h5>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="maliciousSendWithOddHexData"
+                  disabled
+                >
+                  Malicious Eth Transfer With Odd Hex Data
+                </button>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="maliciousApproveERC20WithOddHexData"
+                  disabled
+                >
+                  Malicious ERC20 Approval With Odd Hex Data
+                </button>
+                <h5>Signatures</h5>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="maliciousPermitHexPaddedChain"
+                  disabled
+                >
+                  Malicious Permit with Padded chainId
+                </button>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="maliciousPermitIntAddress"
+                  disabled
+                >
+                  Malicious Permit with Integer Address
                 </button>
               </div>
             </div>
@@ -1348,22 +1416,6 @@
                   disabled
                 >
                 Invalid Transaction Type (not supported)
-                </button>
-
-                <button
-                  class="btn btn-primary btn-lg btn-block mb-3"
-                  id="sendWithOddHexData"
-                  disabled
-                >
-                Send with Odd Hex Data
-                </button>
-
-                <button
-                  class="btn btn-primary btn-lg btn-block mb-3"
-                  id="approveERC20WithOddHexData"
-                  disabled
-                >
-                Approve ERC20 with Odd Hex Data
                 </button>
 
                 <button

--- a/src/index.js
+++ b/src/index.js
@@ -263,10 +263,6 @@ const signMalformedResult = document.getElementById('signMalformedResult');
 // Malformed Transactions
 const sendWithInvalidValue = document.getElementById('sendWithInvalidValue');
 const sendWithInvalidTxType = document.getElementById('sendWithInvalidTxType');
-const sendWithOddHexData = document.getElementById('sendWithOddHexData');
-const approveERC20WithOddHexData = document.getElementById(
-  'approveERC20WithOddHexData',
-);
 const sendWithInvalidRecipient = document.getElementById(
   'sendWithInvalidRecipient',
 );
@@ -325,7 +321,29 @@ const transferTokensDeeplink = document.getElementById(
   'transferTokensDeeplink',
 );
 const approveTokensDeeplink = document.getElementById('approveTokensDeeplink');
+const maliciousSendEthWithDeeplink = document.getElementById(
+  'maliciousSendEthWithDeeplink',
+);
+const maliciousTransferERC20WithDeeplink = document.getElementById(
+  'maliciousTransferERC20WithDeeplink',
+);
+const maliciousApproveERC20WithDeeplink = document.getElementById(
+  'maliciousApproveERC20WithDeeplink',
+);
 
+// PPOM - Malicious Warning Bypasses
+const maliciousSendWithOddHexData = document.getElementById(
+  'maliciousSendWithOddHexData',
+);
+const maliciousApproveERC20WithOddHexData = document.getElementById(
+  'maliciousApproveERC20WithOddHexData',
+);
+const maliciousPermitHexPaddedChain = document.getElementById(
+  'maliciousPermitHexPaddedChain',
+);
+const maliciousPermitIntAddress = document.getElementById(
+  'maliciousPermitIntAddress',
+);
 // Buttons that require connecting an account
 const allConnectedButtons = [
   deployButton,
@@ -410,10 +428,14 @@ const allConnectedButtons = [
   maliciousSeaport,
   sendWithInvalidValue,
   sendWithInvalidTxType,
-  sendWithOddHexData,
-  approveERC20WithOddHexData,
   sendWithInvalidRecipient,
   mintSepoliaERC20,
+  maliciousSendEthWithDeeplink,
+  maliciousSendWithOddHexData,
+  maliciousApproveERC20WithOddHexData,
+  maliciousPermitHexPaddedChain,
+  maliciousPermitIntAddress,
+  maliciousPermitIntAddress,
 ];
 
 // Buttons that are available after initially connecting an account
@@ -456,10 +478,14 @@ const initialConnectedButtons = [
   maliciousPermit,
   maliciousTradeOrder,
   maliciousSeaport,
+  maliciousSendWithOddHexData,
+  maliciousApproveERC20WithOddHexData,
+  maliciousPermitHexPaddedChain,
+  maliciousPermitIntAddress,
   sendWithInvalidValue,
   sendWithInvalidTxType,
-  sendWithOddHexData,
-  approveERC20WithOddHexData,
+  maliciousSendWithOddHexData,
+  maliciousApproveERC20WithOddHexData,
   sendWithInvalidRecipient,
   mintSepoliaERC20,
 ];
@@ -498,10 +524,14 @@ const walletConnectButtons = [
   maliciousSeaport,
   sendWithInvalidValue,
   sendWithInvalidTxType,
-  sendWithOddHexData,
-  approveERC20WithOddHexData,
   sendWithInvalidRecipient,
   mintSepoliaERC20,
+  maliciousSendWithOddHexData,
+  maliciousApproveERC20WithOddHexData,
+  maliciousPermitHexPaddedChain,
+  maliciousPermitIntAddress,
+  maliciousSendWithOddHexData,
+  maliciousApproveERC20WithOddHexData,
 ];
 
 /**
@@ -3070,65 +3100,6 @@ const initializeFormElements = () => {
   };
 
   /**
-   * Send With Odd Hex Data
-   */
-
-  sendWithOddHexData.onclick = async () => {
-    try {
-      const from = accounts[0];
-      const send = await provider.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from,
-            to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
-            value: '0x9184e72a000',
-            data: '0x1', // odd hex data - expected 0x01
-          },
-        ],
-      });
-      sendMalformedResult.innerHTML = send;
-    } catch (err) {
-      console.error(err);
-      sendMalformedResult.innerHTML = `Error: ${err.message}`;
-    }
-  };
-
-  /**
-   * Approve ERC20 With Odd Hex Data
-   */
-
-  approveERC20WithOddHexData.onclick = async () => {
-    let erc20Contract;
-
-    if (networkName) {
-      erc20Contract = ERC20_SAMPLE_CONTRACTS[networkName];
-    } else {
-      erc20Contract = '0x4fabb145d64652a948d72533023f6e7a623c7c53';
-    }
-
-    try {
-      const from = accounts[0];
-      const send = await provider.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from,
-            to: erc20Contract,
-            value: '0x0',
-            // odd approve hex data - expected 0x095ea7b3...
-            data: '0x95ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6000000000000000000000000000000000000000000000000ffffffffffffffff',
-          },
-        ],
-      });
-      sendMalformedResult.innerHTML = send;
-    } catch (err) {
-      console.error(err);
-      sendMalformedResult.innerHTML = `Error: ${err.message}`;
-    }
-  };
-
-  /**
    * Send With Invalid Recipient
    */
 
@@ -3297,6 +3268,82 @@ const initializeFormElements = () => {
   };
 
   /**
+   *  PPOM - Malicious Warning Bypasses
+   */
+  maliciousSendWithOddHexData.onclick = async () => {
+    try {
+      const from = accounts[0];
+      const send = await provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from,
+            to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+            value: '0x9184e72a000',
+            data: '0x1', // odd hex data - expected 0x01
+          },
+        ],
+      });
+      sendMalformedResult.innerHTML = send;
+    } catch (err) {
+      console.error(err);
+      sendMalformedResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  maliciousApproveERC20WithOddHexData.onclick = async () => {
+    let erc20Contract;
+
+    if (networkName) {
+      erc20Contract = ERC20_SAMPLE_CONTRACTS[networkName];
+    } else {
+      erc20Contract = '0x4fabb145d64652a948d72533023f6e7a623c7c53';
+    }
+
+    try {
+      const from = accounts[0];
+      const send = await provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from,
+            to: erc20Contract,
+            value: '0x0',
+            // odd approve hex data - expected 0x095ea7b3...
+            data: '0x95ea7b3000000000000000000000000e50a2dbc466d01a34c3e8b7e8e45fce4f7da39e6000000000000000000000000000000000000000000000000ffffffffffffffff',
+          },
+        ],
+      });
+      sendMalformedResult.innerHTML = send;
+    } catch (err) {
+      console.error(err);
+      sendMalformedResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  maliciousPermitHexPaddedChain.onclick = async () => {
+    const result = await provider.request({
+      method: 'eth_signTypedData_v4',
+      params: [
+        accounts[0],
+        `{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},"primaryType":"Permit","domain":{"name":"USD Coin","verifyingContract":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","chainId":${chainIdInt},"version":"2"},"message":{"owner":"${accounts[0]}","spender":"0x1661F1B207629e4F385DA89cFF535C8E5Eb23Ee3","value":"1033366316628","nonce":1,"deadline":1678709555}}`,
+      ],
+    });
+    console.log(result);
+  };
+
+  maliciousPermitIntAddress.onclick = async () => {
+    const result = await provider.request({
+      method: 'eth_signTypedData_v4',
+      params: [
+        accounts[0],
+        `{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},"primaryType":"Permit","domain":{"name":"USD Coin","verifyingContract":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","chainId":${chainIdInt},"version":"2"},"message":{"owner":"${accounts[0]}","spender":"0x1661F1B207629e4F385DA89cFF535C8E5Eb23Ee3","value":"1033366316628","nonce":1,"deadline":1678709555}}`,
+      ],
+    });
+    console.log(result);
+  };
+
+  /**
    * Providers
    */
 
@@ -3308,6 +3355,11 @@ const setDeeplinks = () => {
     'https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0';
   transferTokensDeeplink.href = `https://metamask.app.link/send/${deployedContractAddress}/transfer?address=0x2f318C334780961FB129D2a6c30D0763d9a5C970&uint256=4e${tokenDecimals}`;
   approveTokensDeeplink.href = `https://metamask.app.link/approve/${deployedContractAddress}/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=3e${tokenDecimals}`;
+  maliciousSendEthWithDeeplink.href =
+    'https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0';
+  maliciousTransferERC20WithDeeplink.href = `https://metamask.app.link/send/${deployedContractAddress}/transfer?address=0x2f318C334780961FB129D2a6c30D0763d9a5C970&uint256=4e${tokenDecimals}`;
+  approveTokensDeeplink.href = `https://metamask.app.link/approve/${deployedContractAddress}/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=3e${tokenDecimals}`;
+  maliciousApproveERC20WithDeeplink.href = `https://metamask.app.link/approve/${deployedContractAddress}/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=3e${tokenDecimals}`;
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -314,6 +314,7 @@ const maliciousSeaport = document.getElementById('maliciousSeaport');
 const maliciousSetApprovalForAll = document.getElementById(
   'maliciousSetApprovalForAll',
 );
+const maliciousAddress = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
 
 // Deeplinks
 const sendDeeplinkButton = document.getElementById('sendDeeplinkButton');
@@ -729,11 +730,13 @@ const handleNewAccounts = (newAccounts) => {
 
 let chainIdInt;
 let networkName;
+let chainIdPadded;
 
 const handleNewChain = (chainId) => {
   chainIdDiv.innerHTML = chainId;
   const networkId = parseInt(networkDiv.innerHTML, 10);
   chainIdInt = parseInt(chainIdDiv.innerHTML, 16) || networkId;
+  chainIdPadded = `0x${chainIdInt.toString(16).padStart(77, '0')}`;
   networkName = NETWORKS_BY_CHAIN_ID[chainIdInt];
 
   if (chainId === '0x1') {
@@ -1666,7 +1669,7 @@ const initializeFormElements = () => {
       params: [
         {
           from: accounts[0],
-          to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+          to: `${maliciousAddress}`,
           value: '0x9184e72a000',
         },
       ],
@@ -1692,7 +1695,7 @@ const initializeFormElements = () => {
       method: 'eth_signTypedData_v4',
       params: [
         accounts[0],
-        `{"types":{"ERC721Order":[{"type":"uint8","name":"direction"},{"type":"address","name":"maker"},{"type":"address","name":"taker"},{"type":"uint256","name":"expiry"},{"type":"uint256","name":"nonce"},{"type":"address","name":"erc20Token"},{"type":"uint256","name":"erc20TokenAmount"},{"type":"Fee[]","name":"fees"},{"type":"address","name":"erc721Token"},{"type":"uint256","name":"erc721TokenId"},{"type":"Property[]","name":"erc721TokenProperties"}],"Fee":[{"type":"address","name":"recipient"},{"type":"uint256","name":"amount"},{"type":"bytes","name":"feeData"}],"Property":[{"type":"address","name":"propertyValidator"},{"type":"bytes","name":"propertyData"}],"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}]},"domain":{"name":"ZeroEx","version":"1.0.0","chainId":${chainIdInt},"verifyingContract":"0xdef1c0ded9bec7f1a1670819833240f027b25eff"},"primaryType":"ERC721Order","message":{"direction":"0","maker":"${accounts[0]}","taker":"0x5FbDB2315678afecb367f032d93F642f64180aa3","expiry":"2524604400","nonce":"100131415900000000000000000000000000000083840314483690155566137712510085002484","erc20Token":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","erc20TokenAmount":"42000000000000","fees":[],"erc721Token":"0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e","erc721TokenId":"2516","erc721TokenProperties":[]}}`,
+        `{"types":{"ERC721Order":[{"type":"uint8","name":"direction"},{"type":"address","name":"maker"},{"type":"address","name":"taker"},{"type":"uint256","name":"expiry"},{"type":"uint256","name":"nonce"},{"type":"address","name":"erc20Token"},{"type":"uint256","name":"erc20TokenAmount"},{"type":"Fee[]","name":"fees"},{"type":"address","name":"erc721Token"},{"type":"uint256","name":"erc721TokenId"},{"type":"Property[]","name":"erc721TokenProperties"}],"Fee":[{"type":"address","name":"recipient"},{"type":"uint256","name":"amount"},{"type":"bytes","name":"feeData"}],"Property":[{"type":"address","name":"propertyValidator"},{"type":"bytes","name":"propertyData"}],"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}]},"domain":{"name":"ZeroEx","version":"1.0.0","chainId":${chainIdInt},"verifyingContract":"0xdef1c0ded9bec7f1a1670819833240f027b25eff"},"primaryType":"ERC721Order","message":{"direction":"0","maker":"${accounts[0]}","taker":${maliciousAddress},"expiry":"2524604400","nonce":"100131415900000000000000000000000000000083840314483690155566137712510085002484","erc20Token":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","erc20TokenAmount":"42000000000000","fees":[],"erc721Token":"0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e","erc721TokenId":"2516","erc721TokenProperties":[]}}`,
       ],
     });
     console.log(result);
@@ -3228,7 +3231,7 @@ const initializeFormElements = () => {
           params: [
             {
               from: accounts[0],
-              to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+              to: `${maliciousAddress}`,
               value: '0x0',
               gasLimit: '0x5028',
               maxFeePerGas: '0x2540be400',
@@ -3278,7 +3281,7 @@ const initializeFormElements = () => {
         params: [
           {
             from,
-            to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+            to: `${maliciousAddress}`,
             value: '0x9184e72a000',
             data: '0x1', // odd hex data - expected 0x01
           },
@@ -3326,7 +3329,7 @@ const initializeFormElements = () => {
       method: 'eth_signTypedData_v4',
       params: [
         accounts[0],
-        `{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},"primaryType":"Permit","domain":{"name":"USD Coin","verifyingContract":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","chainId":${chainIdInt},"version":"2"},"message":{"owner":"${accounts[0]}","spender":"0x1661F1B207629e4F385DA89cFF535C8E5Eb23Ee3","value":"1033366316628","nonce":1,"deadline":1678709555}}`,
+        `{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},"primaryType":"Permit","domain":{"name":"USD Coin","verifyingContract":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","chainId":"${chainIdPadded}","version":"2"},"message":{"owner":"${accounts[0]}","spender":"0x1661F1B207629e4F385DA89cFF535C8E5Eb23Ee3","value":"1033366316628","nonce":1,"deadline":1678709555}}`,
       ],
     });
     console.log(result);
@@ -3337,7 +3340,7 @@ const initializeFormElements = () => {
       method: 'eth_signTypedData_v4',
       params: [
         accounts[0],
-        `{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},"primaryType":"Permit","domain":{"name":"USD Coin","verifyingContract":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","chainId":${chainIdInt},"version":"2"},"message":{"owner":"${accounts[0]}","spender":"0x1661F1B207629e4F385DA89cFF535C8E5Eb23Ee3","value":"1033366316628","nonce":1,"deadline":1678709555}}`,
+        `{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},"primaryType":"Permit","domain":{"name":"USD Coin","verifyingContract":"917551056842671309452305380979543736893630245704","chainId":${chainIdInt},"version":"2"},"message":{"owner":"${accounts[0]}","spender":"0x1661F1B207629e4F385DA89cFF535C8E5Eb23Ee3","value":"1033366316628","nonce":1,"deadline":1678709555}}`,
       ],
     });
     console.log(result);
@@ -3355,11 +3358,9 @@ const setDeeplinks = () => {
     'https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0';
   transferTokensDeeplink.href = `https://metamask.app.link/send/${deployedContractAddress}/transfer?address=0x2f318C334780961FB129D2a6c30D0763d9a5C970&uint256=4e${tokenDecimals}`;
   approveTokensDeeplink.href = `https://metamask.app.link/approve/${deployedContractAddress}/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=3e${tokenDecimals}`;
-  maliciousSendEthWithDeeplink.href =
-    'https://metamask.app.link/send/0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb?value=0';
-  maliciousTransferERC20WithDeeplink.href = `https://metamask.app.link/send/${deployedContractAddress}/transfer?address=0x2f318C334780961FB129D2a6c30D0763d9a5C970&uint256=4e${tokenDecimals}`;
-  approveTokensDeeplink.href = `https://metamask.app.link/approve/${deployedContractAddress}/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=3e${tokenDecimals}`;
-  maliciousApproveERC20WithDeeplink.href = `https://metamask.app.link/approve/${deployedContractAddress}/approve?address=0x178e3e6c9f547A00E33150F7104427ea02cfc747&uint256=3e${tokenDecimals}`;
+  maliciousSendEthWithDeeplink.href = `https://metamask.app.link/send/${maliciousAddress}?value=0`;
+  maliciousTransferERC20WithDeeplink.href = `https://metamask.app.link/send/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48@1/transfer?address=${maliciousAddress}&uint256=1e6`;
+  maliciousApproveERC20WithDeeplink.href = `https://metamask.app.link/approve/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48@1/approve?address=${maliciousAddress}&uint256=1e6`;
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -479,16 +479,16 @@ const initialConnectedButtons = [
   maliciousPermit,
   maliciousTradeOrder,
   maliciousSeaport,
+  sendWithInvalidValue,
+  sendWithInvalidTxType,
+  sendWithInvalidRecipient,
+  mintSepoliaERC20,
   maliciousSendWithOddHexData,
   maliciousApproveERC20WithOddHexData,
   maliciousPermitHexPaddedChain,
   maliciousPermitIntAddress,
-  sendWithInvalidValue,
-  sendWithInvalidTxType,
   maliciousSendWithOddHexData,
   maliciousApproveERC20WithOddHexData,
-  sendWithInvalidRecipient,
-  mintSepoliaERC20,
 ];
 
 // Buttons that are available after connecting via Wallet Connect


### PR DESCRIPTION
### Description
In this PR we add a couple of more functionalities for testing the PPOM feature:
- Added the ability to try Malicious Deeplinks for Mobile -> this has uncovered the following issue https://github.com/MetaMask/metamask-mobile/issues/9365
- Added a new section for Bypasses -> here we gather the identified bypasses for Blockaid. Now all of them are fixed except the **Malicious Permit with Padded ChainId**, but it is fixed in the next MM release, which contains the new ppom version https://github.com/MetaMask/metamask-extension/pull/24171
- Moved the Transfer/Approve with Odd Hex data to the Bypasses section -> this is done since they are better matching to this new section, as those were identified bypasses for Blockaid, opposed to the malformed transactions.
- Added a descriptive text for each section, to help manual QAs

### Screenshots
#### Before

![Screenshot from 2024-04-25 09-50-58](https://github.com/MetaMask/test-dapp/assets/54408225/b90d7e1e-abaa-4d0b-b1ee-f1d2e844fed7)

#### After

![Screenshot from 2024-04-23 21-10-05](https://github.com/MetaMask/test-dapp/assets/54408225/0eb69578-8083-4e7c-973b-06d498e52dc9)


https://github.com/MetaMask/test-dapp/assets/54408225/283028e6-90c2-4175-8041-b7061b217b0a


### Manual QA Steps
1. Build the test dapp locally
2. Try the new bypasses buttons. Note: all bypasses should be flagged except for the Malicious Permit With Padded ChainID (which will be fixed in the ppom updat 1.4.6)
3. Go to Mobile browser
4. Go to localhost:9011
5. Try the deeplinks
6. Open MM and see each deeplink working. Note: all the deeplinks are not flagged by Blockaid at the moment, since there is an issue with Blockaid + Deeplinks in Mobile 
