### PR TITLE
feat: add Blockaid bypass for send value without 0x prefix

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -977,6 +977,13 @@
                 >
                   Malicious ERC20 Approval With Odd Hex Data
                 </button>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="maliciousSendWithoutHexPrefixValue"
+                  disabled
+                >
+                  Malicious Eth Transfer Without 0x Prefix for Hex Value
+                </button>
                 <h5>Signatures</h5>
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"

--- a/src/index.js
+++ b/src/index.js
@@ -339,6 +339,9 @@ const maliciousSendWithOddHexData = document.getElementById(
 const maliciousApproveERC20WithOddHexData = document.getElementById(
   'maliciousApproveERC20WithOddHexData',
 );
+const maliciousSendWithoutHexPrefixValue = document.getElementById(
+  'maliciousSendWithoutHexPrefixValue',
+);
 const maliciousPermitHexPaddedChain = document.getElementById(
   'maliciousPermitHexPaddedChain',
 );
@@ -433,6 +436,7 @@ const allConnectedButtons = [
   mintSepoliaERC20,
   maliciousSendEthWithDeeplink,
   maliciousSendWithOddHexData,
+  maliciousSendWithoutHexPrefixValue,
   maliciousApproveERC20WithOddHexData,
   maliciousPermitHexPaddedChain,
   maliciousPermitIntAddress,
@@ -484,11 +488,10 @@ const initialConnectedButtons = [
   sendWithInvalidRecipient,
   mintSepoliaERC20,
   maliciousSendWithOddHexData,
+  maliciousSendWithoutHexPrefixValue,
   maliciousApproveERC20WithOddHexData,
   maliciousPermitHexPaddedChain,
   maliciousPermitIntAddress,
-  maliciousSendWithOddHexData,
-  maliciousApproveERC20WithOddHexData,
 ];
 
 // Buttons that are available after connecting via Wallet Connect
@@ -528,11 +531,10 @@ const walletConnectButtons = [
   sendWithInvalidRecipient,
   mintSepoliaERC20,
   maliciousSendWithOddHexData,
+  maliciousSendWithoutHexPrefixValue,
   maliciousApproveERC20WithOddHexData,
   maliciousPermitHexPaddedChain,
   maliciousPermitIntAddress,
-  maliciousSendWithOddHexData,
-  maliciousApproveERC20WithOddHexData,
 ];
 
 /**
@@ -3324,6 +3326,25 @@ const initializeFormElements = () => {
     }
   };
 
+  maliciousSendWithoutHexPrefixValue.onclick = async () => {
+    try {
+      const from = accounts[0];
+      const send = await provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from,
+            to: `${maliciousAddress}`,
+            value: 'ffffffffffffff', // value without 0x prefix
+          },
+        ],
+      });
+      sendMalformedResult.innerHTML = send;
+    } catch (err) {
+      console.error(err);
+      sendMalformedResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
   maliciousPermitHexPaddedChain.onclick = async () => {
     const result = await provider.request({
       method: 'eth_signTypedData_v4',


### PR DESCRIPTION
### Description
This PR adds a new identified bypass, where dapps could pass a value in hex, without the `0x` prefix, and this would make the validation fail - but the transaction will succeed.
This is now fixed in the current MM version 11.14, but it was happening in previous versions.

```
window.ethereum.sendAsync({
  "method": "eth_sendTransaction",
  "params": [
    {
          "from": "0x9A4834c232923d7Ff5F8F52741546E14097C2b24",
          "to": "0xbD28258AD16776B34495323F21599761e47f4c8F",
          "value": "ffffff" // see value without 0x
    }
  ],
  "timestamp": 1693229271999
}
)
```

### Screenshots

![Screenshot from 2024-04-26 11-26-50](https://github.com/MetaMask/test-dapp/assets/54408225/552959b7-e8c0-4042-a4cb-4329e6001876)


https://github.com/MetaMask/test-dapp/assets/54408225/8dd578b4-b988-46c9-bf7d-f5cb21d3da62

### Manual QA
1. Install an older version of the wallet ie MM version 11.12
2. Try the new bypass -- see the blockaid validation fails
3. Install 11.14 version of MM
4. Try the new bypass -- see the blockaid validation is successful, bc a fix was released in the last version