### PR TITLE
fix: android and detox E2E issue

### DIFF
--- a/src/connections.js
+++ b/src/connections.js
@@ -28,17 +28,17 @@ export const initializeWeb3Modal = () => {
 
       const web3Modal = createWeb3Modal({
         ethersConfig: defaultConfig({ metadata: dappMetadata }),
-        projectId: 'e6360eaee594162688065f1c70c863b7', // test id
+        projectId: 'e6360eaee594162688065f1c70c863b7',
       });
 
-      console.log('Web3Modal initialized successfully on Android');
+      console.log('Web3Modal initialized successfully');
       return web3Modal;
     } catch (error) {
-      console.error('Error initializing Web3Modal:', error);
+      console.error('Error initializing Web3Modal', error);
     }
   }
 
-  console.log('Web3Modal is not initialized as the platform is Android');
+  console.log('Web3Modal is not initialized');
   return null;
 };
 

--- a/src/connections.js
+++ b/src/connections.js
@@ -21,13 +21,14 @@ const isAndroid = /Android/i.test(navigator.userAgent);
 const sdk = new MetaMaskSDK({ dappMetadata });
 
 export const initializeWeb3Modal = () => {
-  if (isAndroid) {
+  if (!isAndroid) {
     try {
       // eslint-disable-next-line node/global-require
       const { createWeb3Modal, defaultConfig } = require('@web3modal/ethers5');
 
       const web3Modal = createWeb3Modal({
         ethersConfig: defaultConfig({ metadata: dappMetadata }),
+        projectId: 'e6360eaee594162688065f1c70c863b7', // test id
       });
 
       console.log('Web3Modal initialized successfully on Android');

--- a/src/connections.js
+++ b/src/connections.js
@@ -38,7 +38,7 @@ export const initializeWeb3Modal = () => {
     }
   }
 
-  console.log('Web3Modal is not initialized as the platform is not Android');
+  console.log('Web3Modal is not initialized as the platform is Android');
   return null;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -554,7 +554,7 @@ const detectEip6963 = () => {
 export const setActiveProviderDetail = async (providerDetail) => {
   closeProvider();
   provider = providerDetail.provider;
-  initializeProvider();
+  await initializeProvider();
 
   try {
     const newAccounts = await provider.request({
@@ -574,7 +574,7 @@ export const setActiveProviderDetail = async (providerDetail) => {
   updateFormElements();
 };
 
-const setActiveProviderDetailWindowEthereum = () => {
+const setActiveProviderDetailWindowEthereum = async () => {
   const providerDetail = {
     info: {
       uuid: '',
@@ -584,7 +584,7 @@ const setActiveProviderDetailWindowEthereum = () => {
     provider: window.ethereum,
   };
 
-  setActiveProviderDetail(providerDetail);
+  await setActiveProviderDetail(providerDetail);
 };
 
 const existsProviderDetail = (newProviderDetail) => {
@@ -3349,9 +3349,9 @@ const setDeeplinks = () => {
  */
 
 const initialize = async () => {
-  setActiveProviderDetailWindowEthereum();
+  await setActiveProviderDetailWindowEthereum();
   detectEip6963();
-  setActiveProviderDetail(providerDetails[0]);
+  await setActiveProviderDetail(providerDetails[0]);
   initializeFormElements();
   setDeeplinks();
 };


### PR DESCRIPTION
This PR addresses an issue occurring on Android within the Detox build, which prevents interaction with the test dapp. The problem first appeared in version v8.2.0, introduced in [PR #284](https://github.com/MetaMask/test-dapp/pull/284). The issue arises whenever @web3modal/ethers5 is imported, causing the tests to break. This behavior is observed exclusively on Android within the Detox build.