### PR TITLE
fix: use provider for watch asset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1274,7 +1274,7 @@ const initializeFormElements = () => {
     const nftsContractAddress = nftsContract.address;
     let watchNftsResult;
     try {
-      watchNftsResult = await ethereum.sendAsync(
+      watchNftsResult = await provider.sendAsync(
         Array.from({ length: currentTokenId }, (_, i) => i + 1).map(
           (tokenId) => {
             return {
@@ -1508,7 +1508,7 @@ const initializeFormElements = () => {
 
   watchAssetButton.onclick = async () => {
     try {
-      const watchAssetResult = await ethereum.request({
+      const watchAssetResult = await provider.request({
         method: 'wallet_watchAsset',
         params: {
           type: 'ERC1155',


### PR DESCRIPTION
## Description
This is a fix for the watch all nfts and watch ERC1155 dapp actions, which should use provider (whichever is currently selected)

## Screenshots
https://github.com/MetaMask/test-dapp/assets/54408225/5eb94872-dfe9-4a9f-84cc-de9a0b3a757f

