### PR TITLE
[MMSDK] Updates mmsdk to latest and fixes a bad call when extension doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@metamask/eslint-config-nodejs": "^6.0.0",
     "@metamask/eth-sig-util": "^7.0.1",
     "@metamask/onboarding": "^1.0.0",
-    "@metamask/sdk": "^0.26.5",
+    "@metamask/sdk": "^0.27.0",
     "@openzeppelin/contracts": "4.9.6",
     "@walletconnect/modal": "^2.6.2",
     "@web3modal/ethers5": "^3.2.0",

--- a/src/connections.js
+++ b/src/connections.js
@@ -63,7 +63,7 @@ export async function handleSdkConnect(name, button, isConnected) {
     updateFormElements();
     updateSdkConnectionState(false);
     removeProviderDetail(name);
-    sdk.terminate();
+    await sdk.terminate();
     button.innerText = 'Sdk Connect';
     button.classList.add('btn-primary');
     button.classList.remove('btn-danger');

--- a/src/index.js
+++ b/src/index.js
@@ -557,7 +557,7 @@ export const setActiveProviderDetail = async (providerDetail) => {
   // but because the SDK is already init the window.ethereum has been injected
   // this doesn't mean we can refer to it directly as the connection may have
   // not been approved which is there uuid comes in as empty
-  if (!providerDetail || providerDetail.uuid === '') {
+  if (!providerDetail || providerDetail.info.uuid === '') {
     return;
   }
   provider = providerDetail.provider;

--- a/src/index.js
+++ b/src/index.js
@@ -553,6 +553,13 @@ const detectEip6963 = () => {
 
 export const setActiveProviderDetail = async (providerDetail) => {
   closeProvider();
+  // When the extension is not installed the providerDetails comes in undefined
+  // but because the SDK is already init the window.ethereum has been injected
+  // this doesn't mean we can refer to it directly as the connection may have
+  // not been approved which is there uuid comes in as empty
+  if (!providerDetail || providerDetail.uuid === '') {
+    return;
+  }
   provider = providerDetail.provider;
   await initializeProvider();
 
@@ -791,7 +798,7 @@ const initializeProvider = async () => {
 
   if (isMetaMaskInstalled()) {
     provider.autoRefreshOnNetworkChange = false;
-    getNetworkAndChainId();
+    await getNetworkAndChainId();
 
     provider.on('chainChanged', handleNewChain);
     provider.on('chainChanged', handleEIP1559Support);
@@ -3268,7 +3275,11 @@ const setDeeplinks = () => {
 const initialize = async () => {
   await setActiveProviderDetailWindowEthereum();
   detectEip6963();
-  await setActiveProviderDetail(providerDetails[0]);
+  // We only want to set the activeProviderDetail is there is one instead of
+  // assuming it exists
+  if (providerDetails.length > 0) {
+    await setActiveProviderDetail(providerDetails[0]);
+  }
   initializeFormElements();
   setDeeplinks();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,10 +684,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-3.1.1.tgz#e89b840a7af8097a8ed4953d8dc8470d1302d3ef"
   integrity sha512-ihb3B0T/wJm1eUuArYP4lCTSEoZsClHhuWyfo/kMX3m/odpqNcPfsz5O2A3NT7dXCAgWPGDQGPqygCpgeniKMw==
 
-"@metamask/sdk-communication-layer@0.26.4":
-  version "0.26.4"
-  resolved "https://registry.yarnpkg.com/@metamask/sdk-communication-layer/-/sdk-communication-layer-0.26.4.tgz#dda8e33a327f29962095b82c598799b852e40d81"
-  integrity sha512-+X4GEc5mV1gWK4moSswVlKsUh+RsA48qPlkxBLTUxQODSnyBe0TRMxE6mH+bSrfponnTzvBkGUXyEjvDwDjDHw==
+"@metamask/sdk-communication-layer@0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@metamask/sdk-communication-layer/-/sdk-communication-layer-0.27.0.tgz#8d618fadd39f11627d5b3ef1bc72867439e33ff4"
+  integrity sha512-G9LCaQzIqp5WmUmvHN6UUdjWrBh67MbRobmbbs5fcc2+9XFhj3vBgtyleUYjun91jSlPHoZeo+f/Pj4/WoPIJg==
   dependencies:
     bufferutil "^4.0.8"
     date-fns "^2.29.3"
@@ -702,14 +702,14 @@
   dependencies:
     qr-code-styling "^1.6.0-rc.1"
 
-"@metamask/sdk@^0.26.5":
-  version "0.26.5"
-  resolved "https://registry.yarnpkg.com/@metamask/sdk/-/sdk-0.26.5.tgz#8adf2957918d0ec06be499d995da15d2171c058e"
-  integrity sha512-HS/MPQCCYRS+m3dDdGLcAagwYHiPv9iUshDMBjINUywCtfUN4P2BH8xdvPOgtnzRIuRSMXqMWBbZnTvEvBeQvA==
+"@metamask/sdk@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@metamask/sdk/-/sdk-0.27.0.tgz#38617985b8305a0f5d482cdd7af8ddec87968bb7"
+  integrity sha512-6sMjr/0qR700X1svPGEQ4rBdtccidBLeTC27fYQc7r9ROgSixB1DUUAyu/LoySVqt3Hu/Zm7NnAHXuT228ht7A==
   dependencies:
     "@metamask/onboarding" "^1.0.1"
     "@metamask/providers" "16.1.0"
-    "@metamask/sdk-communication-layer" "0.26.4"
+    "@metamask/sdk-communication-layer" "0.27.0"
     "@metamask/sdk-install-modal-web" "0.26.5"
     "@types/dom-screen-wake-lock" "^1.0.0"
     bowser "^2.9.0"


### PR DESCRIPTION
Previously upon checking if the extension is present via EIP6963 the dapp would perform `eth_accounts` and sync chainId but when using the SDK this conflicts as a connection might not exist at that point. This avoids that empty call if extension is not installed and the SDK is used.