### PR TITLE
feat: Add SignTypedData primaryType variants: Blur - Order, PermitBatch, PermitSingle, Seaport - BulkOrder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
 
   overrides: [
     {
-      files: ['src/*.js'],
+      files: ['src/**/*.js'],
       parserOptions: {
         sourceType: 'module',
       },

--- a/src/index.html
+++ b/src/index.html
@@ -1334,6 +1334,58 @@
               </div>
             </div>
           </div>
+
+          <div
+            class="col-xl-4 col-lg-6 col-md-12 col-sm-12 col-12 d-flex align-items-stretch"
+          >
+            <div class="card full-width">
+              <div class="card-body">
+                <h4>
+                  Sign Typed Data Variants
+                </h4>
+                
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signBulkOrder"
+                  disabled
+                >
+                  BulkOrder - OpenSea
+                </button>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signPermitSingle"
+                  disabled
+                >
+                  PermitSingle
+                </button>
+
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signPermitBatch"
+                  disabled
+                >
+                  PermitBatch
+                </button>
+                <button
+                  class="btn btn-primary btn-lg btn-block mb-3"
+                  id="signOrderBlur"
+                  disabled
+                >
+                  Order - Blur
+                </button>
+
+                <p class="info-text alert alert-warning">
+                  Result:
+                  <span id="signPermitVariantResult"></span>
+                  <p class="info-text alert alert-warning" id="signPermitVariantResultR">r: </p>
+                  <p class="info-text alert alert-warning" id="signPermitVariantResultS">s: </p>
+                  <p class="info-text alert alert-warning" id="signPermitVariantResultV">v: </p>
+                </p>
+              </div>
+            </div>
+          </div>
+
           <div
             class="col-xl-4 col-lg-6 col-md-12 col-sm-12 col-12 d-flex align-items-stretch"
           >

--- a/src/index.html
+++ b/src/index.html
@@ -1343,15 +1343,13 @@
                 <h4>
                   Sign Typed Data Variants
                 </h4>
-                
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
-                  id="signBulkOrder"
+                  id="signBlurOrder"
                   disabled
                 >
-                  BulkOrder - OpenSea
+                  Blur - Order
                 </button>
-
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
                   id="signPermitSingle"
@@ -1367,12 +1365,13 @@
                 >
                   PermitBatch
                 </button>
+
                 <button
                   class="btn btn-primary btn-lg btn-block mb-3"
-                  id="signOrderBlur"
+                  id="signSeaportBulkOrder"
                   disabled
                 >
-                  Order - Blur
+                  Seaport - BulkOrder
                 </button>
 
                 <p class="info-text alert alert-warning">

--- a/src/index.js
+++ b/src/index.js
@@ -267,10 +267,10 @@ const signPermitVerifyResult = document.getElementById(
 
 // Sign Typed Data Variants
 
-const signOrderBlur = document.getElementById('signOrderBlur');
+const signBlurOrder = document.getElementById('signBlurOrder');
 const signPermitSingle = document.getElementById('signPermitSingle');
 const signPermitBatch = document.getElementById('signPermitBatch');
-const signBulkOrder = document.getElementById('signBulkOrder');
+const signSeaportBulkOrder = document.getElementById('signSeaportBulkOrder');
 
 const signPermitVariantResult = document.getElementById(
   'signPermitVariantResult',
@@ -468,12 +468,12 @@ const allConnectedButtons = [
   signTypedDataV4Verify,
   signTypedDataV4Batch,
   signTypedDataV4Queue,
-  signBulkOrder,
+  signBlurOrder,
   signPermit,
   signPermitSingle,
   signPermitBatch,
-  signOrderBlur,
   signPermitVerify,
+  signSeaportBulkOrder,
   siwe,
   siweResources,
   siweBadDomain,
@@ -528,11 +528,11 @@ const initialConnectedButtons = [
   signTypedDataV4,
   signTypedDataV4Batch,
   signTypedDataV4Queue,
-  signBulkOrder,
+  signBlurOrder,
   signPermit,
   signPermitSingle,
   signPermitBatch,
-  signOrderBlur,
+  signSeaportBulkOrder,
   siwe,
   siweResources,
   siweBadDomain,
@@ -2806,7 +2806,43 @@ const initializeFormElements = () => {
     }
   };
 
-  // TODO: implement order and bulk order
+  signBlurOrder.onclick = async () => {
+    const from = accounts[0];
+    const msgParams = getPermitMsgParams(
+      {
+        primaryType: MSG_PRIMARY_TYPE.BLUR_ORDER,
+        chainId: chainIdInt,
+      },
+      { fromAddress: from },
+    );
+
+    let sign;
+    let r;
+    let s;
+    let v;
+
+    try {
+      sign = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+
+      const { _r, _s, _v } = splitSig(sign);
+      r = `0x${_r.toString('hex')}`;
+      s = `0x${_s.toString('hex')}`;
+      v = _v.toString();
+
+      signPermitVariantResult.innerHTML = sign;
+      signPermitVariantResultR.innerHTML = `r: ${r}`;
+      signPermitVariantResultS.innerHTML = `s: ${s}`;
+      signPermitVariantResultV.innerHTML = `v: ${v}`;
+      signPermitVerify.disabled = false;
+    } catch (err) {
+      console.error(err);
+      signPermitVariantResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
   signPermitBatch.onclick = async () => {
     const from = accounts[0];
     const msgParams = getPermitMsgParams({
@@ -2847,6 +2883,43 @@ const initializeFormElements = () => {
       primaryType: MSG_PRIMARY_TYPE.PERMIT_SINGLE,
       chainId: chainIdInt,
     });
+
+    let sign;
+    let r;
+    let s;
+    let v;
+
+    try {
+      sign = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+
+      const { _r, _s, _v } = splitSig(sign);
+      r = `0x${_r.toString('hex')}`;
+      s = `0x${_s.toString('hex')}`;
+      v = _v.toString();
+
+      signPermitVariantResult.innerHTML = sign;
+      signPermitVariantResultR.innerHTML = `r: ${r}`;
+      signPermitVariantResultS.innerHTML = `s: ${s}`;
+      signPermitVariantResultV.innerHTML = `v: ${v}`;
+      signPermitVerify.disabled = false;
+    } catch (err) {
+      console.error(err);
+      signPermitVariantResult.innerHTML = `Error: ${err.message}`;
+    }
+  };
+
+  signSeaportBulkOrder.onclick = async () => {
+    const from = accounts[0];
+    const msgParams = getPermitMsgParams(
+      {
+        primaryType: MSG_PRIMARY_TYPE.SEAPORT_BULK_ORDER,
+        chainId: chainIdInt,
+      },
+      { fromAddress: from },
+    );
 
     let sign;
     let r;

--- a/src/index.js
+++ b/src/index.js
@@ -2806,146 +2806,54 @@ const initializeFormElements = () => {
     }
   };
 
+  async function requestSignTypedDataVariant(primaryType) {
+    const from = accounts[0];
+    const msgParams = getPermitMsgParams(
+      {
+        primaryType,
+        chainId: chainIdInt,
+      },
+      { fromAddress: from },
+    );
+
+    let sign;
+    let r;
+    let s;
+    let v;
+
+    try {
+      sign = await provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [from, JSON.stringify(msgParams)],
+      });
+
+      const { _r, _s, _v } = splitSig(sign);
+      r = `0x${_r.toString('hex')}`;
+      s = `0x${_s.toString('hex')}`;
+      v = _v.toString();
+
+      signPermitVariantResult.innerHTML = sign;
+      signPermitVariantResultR.innerHTML = `r: ${r}`;
+      signPermitVariantResultS.innerHTML = `s: ${s}`;
+      signPermitVariantResultV.innerHTML = `v: ${v}`;
+      signPermitVerify.disabled = false;
+    } catch (err) {
+      console.error(err);
+      signPermitVariantResult.innerHTML = `Error: ${err.message}`;
+    }
+  }
+
   signBlurOrder.onclick = async () => {
-    const from = accounts[0];
-    const msgParams = getPermitMsgParams(
-      {
-        primaryType: MSG_PRIMARY_TYPE.BLUR_ORDER,
-        chainId: chainIdInt,
-      },
-      { fromAddress: from },
-    );
-
-    let sign;
-    let r;
-    let s;
-    let v;
-
-    try {
-      sign = await provider.request({
-        method: 'eth_signTypedData_v4',
-        params: [from, JSON.stringify(msgParams)],
-      });
-
-      const { _r, _s, _v } = splitSig(sign);
-      r = `0x${_r.toString('hex')}`;
-      s = `0x${_s.toString('hex')}`;
-      v = _v.toString();
-
-      signPermitVariantResult.innerHTML = sign;
-      signPermitVariantResultR.innerHTML = `r: ${r}`;
-      signPermitVariantResultS.innerHTML = `s: ${s}`;
-      signPermitVariantResultV.innerHTML = `v: ${v}`;
-      signPermitVerify.disabled = false;
-    } catch (err) {
-      console.error(err);
-      signPermitVariantResult.innerHTML = `Error: ${err.message}`;
-    }
+    await requestSignTypedDataVariant(MSG_PRIMARY_TYPE.BLUR_ORDER);
   };
-
   signPermitBatch.onclick = async () => {
-    const from = accounts[0];
-    const msgParams = getPermitMsgParams({
-      primaryType: MSG_PRIMARY_TYPE.PERMIT_BATCH,
-      chainId: chainIdInt,
-    });
-
-    let sign;
-    let r;
-    let s;
-    let v;
-
-    try {
-      sign = await provider.request({
-        method: 'eth_signTypedData_v4',
-        params: [from, JSON.stringify(msgParams)],
-      });
-
-      const { _r, _s, _v } = splitSig(sign);
-      r = `0x${_r.toString('hex')}`;
-      s = `0x${_s.toString('hex')}`;
-      v = _v.toString();
-
-      signPermitVariantResult.innerHTML = sign;
-      signPermitVariantResultR.innerHTML = `r: ${r}`;
-      signPermitVariantResultS.innerHTML = `s: ${s}`;
-      signPermitVariantResultV.innerHTML = `v: ${v}`;
-      signPermitVerify.disabled = false;
-    } catch (err) {
-      console.error(err);
-      signPermitVariantResult.innerHTML = `Error: ${err.message}`;
-    }
+    await requestSignTypedDataVariant(MSG_PRIMARY_TYPE.PERMIT_BATCH);
   };
-
   signPermitSingle.onclick = async () => {
-    const from = accounts[0];
-    const msgParams = getPermitMsgParams({
-      primaryType: MSG_PRIMARY_TYPE.PERMIT_SINGLE,
-      chainId: chainIdInt,
-    });
-
-    let sign;
-    let r;
-    let s;
-    let v;
-
-    try {
-      sign = await provider.request({
-        method: 'eth_signTypedData_v4',
-        params: [from, JSON.stringify(msgParams)],
-      });
-
-      const { _r, _s, _v } = splitSig(sign);
-      r = `0x${_r.toString('hex')}`;
-      s = `0x${_s.toString('hex')}`;
-      v = _v.toString();
-
-      signPermitVariantResult.innerHTML = sign;
-      signPermitVariantResultR.innerHTML = `r: ${r}`;
-      signPermitVariantResultS.innerHTML = `s: ${s}`;
-      signPermitVariantResultV.innerHTML = `v: ${v}`;
-      signPermitVerify.disabled = false;
-    } catch (err) {
-      console.error(err);
-      signPermitVariantResult.innerHTML = `Error: ${err.message}`;
-    }
+    await requestSignTypedDataVariant(MSG_PRIMARY_TYPE.PERMIT_SINGLE);
   };
-
   signSeaportBulkOrder.onclick = async () => {
-    const from = accounts[0];
-    const msgParams = getPermitMsgParams(
-      {
-        primaryType: MSG_PRIMARY_TYPE.SEAPORT_BULK_ORDER,
-        chainId: chainIdInt,
-      },
-      { fromAddress: from },
-    );
-
-    let sign;
-    let r;
-    let s;
-    let v;
-
-    try {
-      sign = await provider.request({
-        method: 'eth_signTypedData_v4',
-        params: [from, JSON.stringify(msgParams)],
-      });
-
-      const { _r, _s, _v } = splitSig(sign);
-      r = `0x${_r.toString('hex')}`;
-      s = `0x${_s.toString('hex')}`;
-      v = _v.toString();
-
-      signPermitVariantResult.innerHTML = sign;
-      signPermitVariantResultR.innerHTML = `r: ${r}`;
-      signPermitVariantResultS.innerHTML = `s: ${s}`;
-      signPermitVariantResultV.innerHTML = `v: ${v}`;
-      signPermitVerify.disabled = false;
-    } catch (err) {
-      console.error(err);
-      signPermitVariantResult.innerHTML = `Error: ${err.message}`;
-    }
+    await requestSignTypedDataVariant(MSG_PRIMARY_TYPE.SEAPORT_BULK_ORDER);
   };
 
   /**

--- a/src/signatures/utils.js
+++ b/src/signatures/utils.js
@@ -6,9 +6,12 @@ export const EIP712Domain = [
 ];
 
 export const MSG_PRIMARY_TYPE = {
+  BLUR_ORDER: 'Order',
+  BLUR_ROOT: 'Root',
   PERMIT: 'Permit',
   PERMIT_BATCH: 'PermitBatch',
   PERMIT_SINGLE: 'PermitSingle',
+  SEAPORT_BULK_ORDER: 'BulkOrder',
 };
 
 export function getPermitMsgParams(
@@ -16,6 +19,51 @@ export function getPermitMsgParams(
   { fromAddress } = {},
 ) {
   switch (primaryType) {
+    case MSG_PRIMARY_TYPE.BLUR_ORDER: {
+      return {
+        primaryType: 'Order',
+        types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+          ],
+          Order: [
+            { name: 'trader', type: 'address' }, // User address
+            { name: 'side', type: 'uint8' }, // Buy or Sell (0 = Buy, 1 = Sell)
+            { name: 'collection', type: 'address' }, // NFT collection address
+            { name: 'tokenId', type: 'uint256' }, // Token ID of the NFT
+            { name: 'price', type: 'uint256' }, // Price in Wei
+            { name: 'quantity', type: 'uint256' }, // Quantity of tokens
+            { name: 'nonce', type: 'uint256' }, // Nonce for order uniqueness
+            { name: 'expirationTime', type: 'uint256' }, // Order expiration time in seconds
+          ],
+        },
+        domain: {
+          name: 'Blur Exchange',
+          version: '1.0',
+          chainId,
+          verifyingContract: '0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5',
+        },
+        message: {
+          trader: fromAddress,
+          collection: '0x8a90cab2b38dba80c64b7734e58ee1db38b8992e',
+          listingsRoot:
+            '0xf5126e36e0cf3f8ccdf8e3d76c1501c706c15a029fb8139bca7b536776e9eafe',
+          numberOfListings: '1',
+          expirationTime: '1739484503',
+          assetType: '0',
+          makerFee: {
+            recipient: '0x0000000000000000000000000000000000000000',
+            rate: '0',
+          },
+          salt: '106171581059276559763059578085820161781',
+          orderType: '1',
+          nonce: '0',
+        },
+      };
+    }
     case MSG_PRIMARY_TYPE.PERMIT: {
       return {
         types: {
@@ -174,6 +222,219 @@ export function getPermitMsgParams(
           },
           spender: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad',
           sigDeadline: '1720297342',
+        },
+      };
+    }
+    case MSG_PRIMARY_TYPE.SEAPORT_BULK_ORDER: {
+      return {
+        primaryType: 'BulkOrder',
+        types: {
+          BulkOrder: [{ name: 'tree', type: 'OrderComponents[][]' }],
+          OrderComponents: [
+            { name: 'offerer', type: 'address' },
+            { name: 'zone', type: 'address' },
+            { name: 'offer', type: 'OfferItem[]' },
+            { name: 'consideration', type: 'ConsiderationItem[]' },
+            { name: 'orderType', type: 'uint8' },
+            { name: 'startTime', type: 'uint256' },
+            { name: 'endTime', type: 'uint256' },
+            { name: 'zoneHash', type: 'bytes32' },
+            { name: 'salt', type: 'uint256' },
+            { name: 'conduitKey', type: 'bytes32' },
+            { name: 'counter', type: 'uint256' },
+          ],
+          OfferItem: [
+            { name: 'itemType', type: 'uint8' },
+            { name: 'token', type: 'address' },
+            { name: 'identifierOrCriteria', type: 'uint256' },
+            { name: 'startAmount', type: 'uint256' },
+            { name: 'endAmount', type: 'uint256' },
+          ],
+          ConsiderationItem: [
+            { name: 'itemType', type: 'uint8' },
+            { name: 'token', type: 'address' },
+            { name: 'identifierOrCriteria', type: 'uint256' },
+            { name: 'startAmount', type: 'uint256' },
+            { name: 'endAmount', type: 'uint256' },
+            { name: 'recipient', type: 'address' },
+          ],
+        },
+        domain: {
+          name: 'Seaport',
+          version: '1.5',
+          chainId,
+          verifyingContract: '0x00000000000000ADc04C56Bf30aC9d3c0aAF14dC',
+        },
+        message: {
+          tree: [
+            [
+              {
+                offerer: fromAddress,
+                offer: [
+                  {
+                    itemType: '2',
+                    token: '0xafd4896984CA60d2feF66136e57f958dCe9482d5',
+                    identifierOrCriteria: '2104',
+                    startAmount: '1',
+                    endAmount: '1',
+                  },
+                ],
+                consideration: [
+                  {
+                    itemType: '0',
+                    token: '0x0000000000000000000000000000000000000000',
+                    identifierOrCriteria: '0',
+                    startAmount: '900000000000000000',
+                    endAmount: '900000000000000000',
+                    recipient: fromAddress,
+                  },
+                  {
+                    itemType: '0',
+                    token: '0x0000000000000000000000000000000000000000',
+                    identifierOrCriteria: '0',
+                    startAmount: '25000000000000000',
+                    endAmount: '25000000000000000',
+                    recipient: '0x0000a26b00c1F0DF003000390027140000fAa719',
+                  },
+                  {
+                    itemType: '0',
+                    token: '0x0000000000000000000000000000000000000000',
+                    identifierOrCriteria: '0',
+                    startAmount: '75000000000000000',
+                    endAmount: '75000000000000000',
+                    recipient: '0x839221C3F9dce0ef5318356c447F8192eD04d38C',
+                  },
+                ],
+                startTime: '1705733618',
+                endTime: '1708411897',
+                orderType: '0',
+                zone: '0x004C00500000aD104D7DBd00e3ae0A5C00560C00',
+                zoneHash:
+                  '0x0000000000000000000000000000000000000000000000000000000000000000',
+                salt: '24446860302761739304752683030156737591518664810215442929806792077947493999137',
+                conduitKey:
+                  '0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000',
+                totalOriginalConsiderationItems: '3',
+                counter: '0',
+              },
+              {
+                offerer: fromAddress,
+                offer: [
+                  {
+                    itemType: '2',
+                    token: '0xafd4896984CA60d2feF66136e57f958dCe9482d5',
+                    identifierOrCriteria: '2103',
+                    startAmount: '1',
+                    endAmount: '1',
+                  },
+                ],
+                consideration: [
+                  {
+                    itemType: '0',
+                    token: '0x0000000000000000000000000000000000000000',
+                    identifierOrCriteria: '0',
+                    startAmount: '900000000000000000',
+                    endAmount: '900000000000000000',
+                    recipient: fromAddress,
+                  },
+                  {
+                    itemType: '0',
+                    token: '0x0000000000000000000000000000000000000000',
+                    identifierOrCriteria: '0',
+                    startAmount: '25000000000000000',
+                    endAmount: '25000000000000000',
+                    recipient: '0x0000a26b00c1F0DF003000390027140000fAa719',
+                  },
+                  {
+                    itemType: '0',
+                    token: '0x0000000000000000000000000000000000000000',
+                    identifierOrCriteria: '0',
+                    startAmount: '75000000000000000',
+                    endAmount: '75000000000000000',
+                    recipient: '0x839221C3F9dce0ef5318356c447F8192eD04d38C',
+                  },
+                ],
+                startTime: '1705733618',
+                endTime: '1708411897',
+                orderType: '0',
+                zone: '0x004C00500000aD104D7DBd00e3ae0A5C00560C00',
+                zoneHash:
+                  '0x0000000000000000000000000000000000000000000000000000000000000000',
+                salt: '24446860302761739304752683030156737591518664810215442929800482629144425056459',
+                conduitKey:
+                  '0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000',
+                totalOriginalConsiderationItems: '3',
+                counter: '0',
+              },
+            ],
+            [
+              {
+                offerer: fromAddress,
+                offer: [
+                  {
+                    itemType: '2',
+                    token: '0xafd4896984CA60d2feF66136e57f958dCe9482d5',
+                    identifierOrCriteria: '2102',
+                    startAmount: '1',
+                    endAmount: '1',
+                  },
+                ],
+                consideration: [
+                  {
+                    itemType: '0',
+                    token: '0x0000000000000000000000000000000000000000',
+                    identifierOrCriteria: '0',
+                    startAmount: '900000000000000000',
+                    endAmount: '900000000000000000',
+                    recipient: fromAddress,
+                  },
+                  {
+                    itemType: '0',
+                    token: '0x0000000000000000000000000000000000000000',
+                    identifierOrCriteria: '0',
+                    startAmount: '25000000000000000',
+                    endAmount: '25000000000000000',
+                    recipient: '0x0000a26b00c1F0DF003000390027140000fAa719',
+                  },
+                  {
+                    itemType: '0',
+                    token: '0x0000000000000000000000000000000000000000',
+                    identifierOrCriteria: '0',
+                    startAmount: '75000000000000000',
+                    endAmount: '75000000000000000',
+                    recipient: '0x839221C3F9dce0ef5318356c447F8192eD04d38C',
+                  },
+                ],
+                startTime: '1705733618',
+                endTime: '1708411897',
+                orderType: '0',
+                zone: '0x004C00500000aD104D7DBd00e3ae0A5C00560C00',
+                zoneHash:
+                  '0x0000000000000000000000000000000000000000000000000000000000000000',
+                salt: '24446860302761739304752683030156737591518664810215442929800836178870704788113',
+                conduitKey:
+                  '0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000',
+                totalOriginalConsiderationItems: '3',
+                counter: '0',
+              },
+              {
+                offerer: '0x0000000000000000000000000000000000000000',
+                zone: '0x0000000000000000000000000000000000000000',
+                offer: [],
+                consideration: [],
+                orderType: '0',
+                startTime: '0',
+                endTime: '0',
+                zoneHash:
+                  '0x0000000000000000000000000000000000000000000000000000000000000000',
+                salt: '0',
+                conduitKey:
+                  '0x0000000000000000000000000000000000000000000000000000000000000000',
+                counter: '0',
+                totalOriginalConsiderationItems: '0',
+              },
+            ],
+          ],
         },
       };
     }

--- a/src/signatures/utils.js
+++ b/src/signatures/utils.js
@@ -66,6 +66,7 @@ export function getPermitMsgParams(
     }
     case MSG_PRIMARY_TYPE.PERMIT: {
       return {
+        primaryType: 'Permit',
         types: {
           EIP712Domain,
           Permit: [
@@ -76,7 +77,6 @@ export function getPermitMsgParams(
             { name: 'deadline', type: 'uint256' },
           ],
         },
-        primaryType: 'Permit',
         domain: {
           chainId,
           name: 'MyToken',
@@ -94,6 +94,7 @@ export function getPermitMsgParams(
     }
     case MSG_PRIMARY_TYPE.PERMIT_BATCH: {
       return {
+        primaryType: 'PermitBatch',
         types: {
           PermitBatch: [
             {
@@ -148,7 +149,6 @@ export function getPermitMsgParams(
           verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
           version: '1',
         },
-        primaryType: 'PermitBatch',
         message: {
           details: [
             {
@@ -171,6 +171,7 @@ export function getPermitMsgParams(
     }
     case MSG_PRIMARY_TYPE.PERMIT_SINGLE: {
       return {
+        primaryType: 'PermitSingle',
         types: {
           PermitSingle: [
             {
@@ -212,7 +213,6 @@ export function getPermitMsgParams(
           verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
           version: '1',
         },
-        primaryType: 'PermitSingle',
         message: {
           details: {
             token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',

--- a/src/signatures/utils.js
+++ b/src/signatures/utils.js
@@ -1,0 +1,186 @@
+export const EIP712Domain = [
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+];
+
+export const MSG_PRIMARY_TYPE = {
+  PERMIT: 'Permit',
+  PERMIT_BATCH: 'PermitBatch',
+  PERMIT_SINGLE: 'PermitSingle',
+};
+
+export function getPermitMsgParams(
+  { chainId, primaryType },
+  { fromAddress } = {},
+) {
+  switch (primaryType) {
+    case MSG_PRIMARY_TYPE.PERMIT: {
+      return {
+        types: {
+          EIP712Domain,
+          Permit: [
+            { name: 'owner', type: 'address' },
+            { name: 'spender', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'nonce', type: 'uint256' },
+            { name: 'deadline', type: 'uint256' },
+          ],
+        },
+        primaryType: 'Permit',
+        domain: {
+          chainId,
+          name: 'MyToken',
+          verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+          version: '1',
+        },
+        message: {
+          owner: fromAddress,
+          spender: '0x5B38Da6a701c568545dCfcB03FcB875f56beddC4',
+          value: 3000,
+          nonce: 0,
+          deadline: 50000000000,
+        },
+      };
+    }
+    case MSG_PRIMARY_TYPE.PERMIT_BATCH: {
+      return {
+        types: {
+          PermitBatch: [
+            {
+              name: 'details',
+              type: 'PermitDetails[]',
+            },
+            {
+              name: 'spender',
+              type: 'address',
+            },
+            {
+              name: 'sigDeadline',
+              type: 'uint256',
+            },
+          ],
+          PermitDetails: [
+            {
+              name: 'token',
+              type: 'address',
+            },
+            {
+              name: 'amount',
+              type: 'uint160',
+            },
+            {
+              name: 'expiration',
+              type: 'uint48',
+            },
+            {
+              name: 'nonce',
+              type: 'uint48',
+            },
+          ],
+          EIP712Domain: [
+            {
+              name: 'name',
+              type: 'string',
+            },
+            {
+              name: 'chainId',
+              type: 'uint256',
+            },
+            {
+              name: 'verifyingContract',
+              type: 'address',
+            },
+          ],
+        },
+        domain: {
+          chainId,
+          name: 'Permit2',
+          verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
+          version: '1',
+        },
+        primaryType: 'PermitBatch',
+        message: {
+          details: [
+            {
+              token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              amount: '1461501637330902918203684832716283019655932542975',
+              expiration: '1722887542',
+              nonce: '5',
+            },
+            {
+              token: '0xb0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              amount: '98765432109876543210',
+              expiration: '1722887642',
+              nonce: '6',
+            },
+          ],
+          spender: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad',
+          sigDeadline: '1720297342',
+        },
+      };
+    }
+    case MSG_PRIMARY_TYPE.PERMIT_SINGLE: {
+      return {
+        types: {
+          PermitSingle: [
+            {
+              name: 'details',
+              type: 'PermitDetails',
+            },
+            {
+              name: 'spender',
+              type: 'address',
+            },
+            {
+              name: 'sigDeadline',
+              type: 'uint256',
+            },
+          ],
+          PermitDetails: [
+            {
+              name: 'token',
+              type: 'address',
+            },
+            {
+              name: 'amount',
+              type: 'uint160',
+            },
+            {
+              name: 'expiration',
+              type: 'uint48',
+            },
+            {
+              name: 'nonce',
+              type: 'uint48',
+            },
+          ],
+          EIP712Domain,
+        },
+        domain: {
+          chainId,
+          name: 'Permit2',
+          verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
+          version: '1',
+        },
+        primaryType: 'PermitSingle',
+        message: {
+          details: {
+            token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            amount: '1461501637330902918203684832716283019655932542975',
+            expiration: '1722887542',
+            nonce: '5',
+          },
+          spender: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad',
+          sigDeadline: '1720297342',
+        },
+      };
+    }
+    default: {
+      throw new Error(
+        `Unknown Sign Typed Signature primary type: ${primaryType}`,
+      );
+    }
+  }
+}

--- a/src/signatures/utils.js
+++ b/src/signatures/utils.js
@@ -29,15 +29,21 @@ export function getPermitMsgParams(
             { name: 'chainId', type: 'uint256' },
             { name: 'verifyingContract', type: 'address' },
           ],
+          MakerFee: [
+            { name: 'recipient', type: 'address' }, // Maker fee recipient address
+            { name: 'rate', type: 'uint256' }, // Maker fee rate
+          ],
           Order: [
-            { name: 'trader', type: 'address' }, // User address
-            { name: 'side', type: 'uint8' }, // Buy or Sell (0 = Buy, 1 = Sell)
+            { name: 'assetType', type: 'uint8' }, // Asset type
             { name: 'collection', type: 'address' }, // NFT collection address
-            { name: 'tokenId', type: 'uint256' }, // Token ID of the NFT
-            { name: 'price', type: 'uint256' }, // Price in Wei
-            { name: 'quantity', type: 'uint256' }, // Quantity of tokens
-            { name: 'nonce', type: 'uint256' }, // Nonce for order uniqueness
             { name: 'expirationTime', type: 'uint256' }, // Order expiration time in seconds
+            { name: 'listingsRoot', type: 'bytes32' }, // Listings root hash
+            { name: 'makerFee', type: 'MakerFee' }, // Maker fee
+            { name: 'nonce', type: 'uint256' }, // Nonce for order uniqueness
+            { name: 'numberOfListings', type: 'uint256' }, // Number of listings
+            { name: 'orderType', type: 'uint8' }, // Order type
+            { name: 'salt', type: 'uint256' }, // Salt for order uniqueness
+            { name: 'trader', type: 'address' }, // User address
           ],
         },
         domain: {
@@ -47,20 +53,20 @@ export function getPermitMsgParams(
           verifyingContract: '0xb2ecfe4e4d61f8790bbb9de2d1259b9e2410cea5',
         },
         message: {
-          trader: fromAddress,
+          assetType: '0',
           collection: '0x8a90cab2b38dba80c64b7734e58ee1db38b8992e',
+          expirationTime: '1739484503',
           listingsRoot:
             '0xf5126e36e0cf3f8ccdf8e3d76c1501c706c15a029fb8139bca7b536776e9eafe',
-          numberOfListings: '1',
-          expirationTime: '1739484503',
-          assetType: '0',
           makerFee: {
             recipient: '0x0000000000000000000000000000000000000000',
             rate: '0',
           },
-          salt: '106171581059276559763059578085820161781',
-          orderType: '1',
           nonce: '0',
+          numberOfListings: '1',
+          orderType: '1',
+          salt: '106171581059276559763059578085820161781',
+          trader: fromAddress,
         },
       };
     }


### PR DESCRIPTION
### Description

- Add signTypedData_v4 primaryType variants to test and assist development
- I lefted the verify signature out for now. We can add it upon request
- updated eslint to support nested .js modules


### Related Issues

Fixes https://github.com/MetaMask/test-dapp/issues/358
Fixes https://github.com/orgs/MetaMask/projects/78/views/1?visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C90948625%2C%22Linked+pull+requests%22%5D&filterQuery=-label%3Aepic+-status%3A%22%E2%9C%85+Done%22+-status%3A%22%E2%9D%8C+Won%27t+do%22+-is%3Apr+-label%3A%22area-documentation%22+test-dapp&pane=issue&itemId=81094156&issue=MetaMask%7CMetaMask-planning%7C3320

### Screenshots

#### After
![CleanShot 2024-11-27 at 20 05 06@2x](https://github.com/user-attachments/assets/7dd74500-33b4-42d3-a276-ebba6fa11a12)
![CleanShot 2024-11-27 at 20 03 24@2x](https://github.com/user-attachments/assets/cb3a9aa9-6812-4d18-99da-5f6c014e586c)

<img width="320" src="https://github.com/user-attachments/assets/1117f5f5-5384-4782-951a-f36de9c4968b">
<img width="320" src="https://github.com/user-attachments/assets/970fee66-391e-45ef-8652-3afd7072f333">
<img width="320" src="https://github.com/user-attachments/assets/6de121df-9e35-4adc-bd71-cb457ff2bf6a">
<img width="320" src="https://github.com/user-attachments/assets/d45fdc21-800b-432b-982b-69de245ad54d">