### PR TITLE
Release Candidate v9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [9.0.0]
+### Added
+- Add SignTypedData primaryType variants: Blur - Order, PermitBatch, PermitSingle, Seaport - BulkOrder ([#376](https://github.com/MetaMask/test-dapp/pull/376))
+
+### Changed
+- Move all components to separate files, use shared global state and events for updating cards based on connect / disconnect / deploy contract ([#379](https://github.com/MetaMask/test-dapp/pull/379))
+
 ## [8.13.0]
 ### Changed
 - Fix malicious trade order button on test dapp ([#373](https://github.com/MetaMask/test-dapp/pull/373))
@@ -222,7 +228,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
-[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v8.13.0...HEAD
+[9.0.0]: https://github.com/MetaMask/test-dapp/compare/v8.13.0...v9.0.0
 [8.13.0]: https://github.com/MetaMask/test-dapp/compare/v8.12.0...v8.13.0
 [8.12.0]: https://github.com/MetaMask/test-dapp/compare/v8.11.0...v8.12.0
 [8.11.0]: https://github.com/MetaMask/test-dapp/compare/v8.10.0...v8.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 ## [9.0.0]
 ### Added
 - Add SignTypedData primaryType variants: Blur - Order, PermitBatch, PermitSingle, Seaport - BulkOrder ([#376](https://github.com/MetaMask/test-dapp/pull/376))
@@ -228,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
+[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v9.0.0...HEAD
 [9.0.0]: https://github.com/MetaMask/test-dapp/compare/v8.13.0...v9.0.0
 [8.13.0]: https://github.com/MetaMask/test-dapp/compare/v8.12.0...v8.13.0
 [8.12.0]: https://github.com/MetaMask/test-dapp/compare/v8.11.0...v8.12.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "8.13.0",
+  "version": "9.0.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 18.0.0"


### PR DESCRIPTION
This is the release candidate PR for `v9.0.0`

### Added
- Add SignTypedData primaryType variants: Blur - Order, PermitBatch, PermitSingle, Seaport - BulkOrder ([#376](https://github.com/MetaMask/test-dapp/pull/376))

### Changed
- Move all components to separate files, use shared global state and events for updating cards based on connect / disconnect / deploy contract ([#379](https://github.com/MetaMask/test-dapp/pull/379))