### PR TITLE
fix: update send calls default calls

### DIFF
--- a/src/components/transactions/eip5792/sendCalls.js
+++ b/src/components/transactions/eip5792/sendCalls.js
@@ -1,5 +1,7 @@
 import globalContext from '../../..';
 
+const VERSION = '1.0';
+
 const DEFAULT_CALLS = [
   {
     to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
@@ -143,6 +145,7 @@ export function sendCallsComponent(parentContainer) {
     const calls = useInputs ? getCalls() : DEFAULT_CALLS;
 
     return {
+      version: VERSION,
       from,
       chainId,
       calls,

--- a/src/components/transactions/eip5792/sendCalls.js
+++ b/src/components/transactions/eip5792/sendCalls.js
@@ -4,12 +4,12 @@ const DEFAULT_CALLS = [
   {
     to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
     data: '0x654365436543',
-    value: '0x1234123412341234',
+    value: '0x3B9ACA00', // 1 Gwei
   },
   {
-    to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+    to: '0xbc2114a988e9CEf5bA63548D432024f34B487048',
     data: '0x789078907890',
-    value: '0x4321432143214321',
+    value: '0x1DCD6500', // 0.5 Gwei
   },
 ];
 


### PR DESCRIPTION
Update default calls in `wallet_sendCalls` request.

- Reduce `value` to 1 Gwei and 0.5 Gwei.
- Use random address rather than malicious address for second call.
- Add `version` to request.