### PR TITLE
Set yarn resolution for `elliptic@^6.6.1` to fix critical security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "url": "https://github.com/MetaMask/test-dapp/issues"
   },
   "homepage": "https://metamask.github.io/test-dapp",
+  "resolutions": {
+    "elliptic": "^6.6.1"
+  },
   "dependencies": {},
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2905,10 +2905,10 @@ electron-to-chromium@^1.4.668:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.754.tgz#20a9f3cc80e0fb6a804b86605e55da16918a58b0"
   integrity sha512-7Kr5jUdns5rL/M9wFFmMZAgFDuL2YOnanFH4OI4iFzUqyh3XOL7nAGbSlSMZdzKMIyyTpNSbqZsWG9odwLeKvA==
 
-elliptic@6.5.4, elliptic@^6.5.2:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
-  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
- See https://github.com/advisories/GHSA-vjh7-7g9h-fjfh
- See https://github.com/MetaMask/supply-chain-tracker/issues/1

Yarn resolution field necessary to keep lockfile stable while resolving to `elliptic@^6.6.1`.  