### PR TITLE
Release Candidate v9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [9.1.0]
+### Added
+- feat: add EIP-5792 section ([#388](https://github.com/MetaMask/test-dapp/pull/388))
+- feat: add send with heavy hex data ([#386](https://github.com/MetaMask/test-dapp/pull/386))
+
+### Changed
+- chore: updated icon ([#391](https://github.com/MetaMask/test-dapp/pull/391))
+
+### Fixed
+- fix: update send calls default calls ([#389](https://github.com/MetaMask/test-dapp/pull/389))
+
 ## [9.0.0]
 ### Added
 - Add SignTypedData primaryType variants: Blur - Order, PermitBatch, PermitSingle, Seaport - BulkOrder ([#376](https://github.com/MetaMask/test-dapp/pull/376))
@@ -229,7 +240,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
-[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v9.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v9.1.0...HEAD
+[9.1.0]: https://github.com/MetaMask/test-dapp/compare/v9.0.0...v9.1.0
 [9.0.0]: https://github.com/MetaMask/test-dapp/compare/v8.13.0...v9.0.0
 [8.13.0]: https://github.com/MetaMask/test-dapp/compare/v8.12.0...v8.13.0
 [8.12.0]: https://github.com/MetaMask/test-dapp/compare/v8.11.0...v8.12.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 18.0.0"


### PR DESCRIPTION
This is the release candidate PR for v9.1.0.

### Added
- feat: add EIP-5792 section ([#388](https://github.com/MetaMask/test-dapp/pull/388))
- feat: add send with heavy hex data ([#386](https://github.com/MetaMask/test-dapp/pull/386))

### Changed
- chore: updated icon ([#391](https://github.com/MetaMask/test-dapp/pull/391))

### Fixed
- fix: update send calls default calls ([#389](https://github.com/MetaMask/test-dapp/pull/389))