### PR TITLE
fix: Increase hardcoded gas limit

### DIFF
--- a/src/components/ppom/batching.js
+++ b/src/components/ppom/batching.js
@@ -1,5 +1,6 @@
 import globalContext from '../..';
 import { maliciousAddress } from '../../sample-addresses';
+import { MIN_GAS_LIMIT } from '../../shared/constants';
 
 export function ppomMaliciousBatchingAndQueueing(parentContainer) {
   parentContainer.insertAdjacentHTML(
@@ -135,7 +136,7 @@ export function ppomMaliciousBatchingAndQueueing(parentContainer) {
               from: globalContext.accounts[0],
               to: `${maliciousAddress}`,
               value: '0x0',
-              gasLimit: '0x5028',
+              gasLimit: MIN_GAS_LIMIT,
               maxFeePerGas: '0x2540be400',
               maxPriorityFeePerGas: '0x3b9aca00',
             },
@@ -160,7 +161,7 @@ export function ppomMaliciousBatchingAndQueueing(parentContainer) {
               from: globalContext.accounts[0],
               to: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
               value: '0x0',
-              gasLimit: '0x5028',
+              gasLimit: MIN_GAS_LIMIT,
               maxFeePerGas: '0x2540be400',
               maxPriorityFeePerGas: '0x3b9aca00',
             },

--- a/src/components/signatures/malformed-transactions.js
+++ b/src/components/signatures/malformed-transactions.js
@@ -1,4 +1,5 @@
 import globalContext from '../..';
+import { MIN_GAS_LIMIT } from '../../shared/constants';
 
 // Malformed Signatues
 
@@ -219,7 +220,7 @@ export function malformedTransactionsComponent(parentContainer) {
             from,
             to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
             value: '0x0',
-            gasLimit: '0x5028',
+            gasLimit: MIN_GAS_LIMIT,
             maxFeePerGas: 'invalid', // invalid maxFeePerGas - expected int/hex value
             maxPriorityFeePerGas: '0x3b9aca00',
           },

--- a/src/components/transactions/send.js
+++ b/src/components/transactions/send.js
@@ -1,5 +1,6 @@
 import globalContext from '../..';
 import Constants from '../../constants.json';
+import { MIN_GAS_LIMIT } from '../../shared/constants';
 
 const { heavyCallData } = Constants;
 
@@ -255,7 +256,7 @@ export function sendComponent(parentContainer) {
           from: globalContext.accounts[0],
           to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
           value: '0x0',
-          gasLimit: '0x5028',
+          gasLimit: MIN_GAS_LIMIT,
           maxFeePerGas: '0x2540be400',
           maxPriorityFeePerGas: '0x3b9aca00',
         },
@@ -367,7 +368,7 @@ export function sendComponent(parentContainer) {
             from: globalContext.accounts[0],
             to: contract.address,
             value: '0x0',
-            gasLimit: '0x5028',
+            gasLimit: MIN_GAS_LIMIT,
             maxFeePerGas: '0x2540be400',
             maxPriorityFeePerGas: '0x3b9aca00',
           },
@@ -418,7 +419,7 @@ export function sendComponent(parentContainer) {
             from: globalContext.accounts[0],
             to: contract.address,
             value: '0x16345785D8A0', // 24414062500000
-            gasLimit: '0x5028',
+            gasLimit: MIN_GAS_LIMIT,
             maxFeePerGas: '0x2540be400',
             maxPriorityFeePerGas: '0x3b9aca00',
           },

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -1,0 +1,2 @@
+// 21000 in hexadecimal
+export const MIN_GAS_LIMIT = '0x5208';


### PR DESCRIPTION
Probably due to a typo, the hardcoded gas limit on simple send flows was previously `0x5028` (20520 in decimal). This PR changes it to `0x5208` (21000 in decimal).