### PR TITLE
feat: tempo change default erc20 to mainnet

### DIFF
--- a/src/components/tempo-transactions/tempo-transactions.js
+++ b/src/components/tempo-transactions/tempo-transactions.js
@@ -3,7 +3,7 @@ import globalContext from '../..';
 // Tempo Transactions
 
 // ERC20 TST token created and owned by shared account 0x13b7e6EBcd40777099E4c45d407745aB2de1D1F8
-const defaultErc20TokenAddress = '0x54a114fecE3dffd7c5D4089D0A43E01F0939464c';
+const defaultErc20TokenAddress = '0x8757b7EABAAaC8173DF72B868B4947FaE1368784';
 // pathUSD (default Tempo fee token
 const defaultFeeToken = '0x20c0000000000000000000000000000000000000';
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low code-change risk (a single constant update), but it changes the default token used for transactions, which could cause unintended sends on mainnet if users don’t override the address.
> 
> **Overview**
> Updates the Tempo Transactions UI to default the ERC20 token address (`defaultErc20TokenAddress`) to a new value (intended for mainnet), changing what token is prefilled and used by default when sending the sample `0x76` batch transaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f08797b3b3b3c75c4d2f01af7fddda40953b1b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->