### PR TITLE
release candidate 9.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [9.9.0]
+### Added
+- Add Tempo to the network picker ([#429](https://github.com/MetaMask/test-dapp/pull/429))
+- Add Tempo panel with batch tx ([#427](https://github.com/MetaMask/test-dapp/pull/427))
+- Add transaction data for EIP5792 sendCalls ([#428](https://github.com/MetaMask/test-dapp/pull/428))
+- Add HyperEVM, MegaETH and Monad to the network picker ([#426](https://github.com/MetaMask/test-dapp/pull/426))
+
+### Changed
+- Change Tempo default ERC20 address to a Mainnet address ([#430](https://github.com/MetaMask/test-dapp/pull/430))
+
 ## [9.8.0]
 ### Added
 - Add a new Send Calls - Required Assets button to the EIP-5792 send calls section ([#423](https://github.com/MetaMask/test-dapp/pull/423))
@@ -280,7 +291,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix repository standardization issues ([#118](https://github.com/MetaMask/test-dapp/pull/118))
 - Fix addEthereumChain button disable logic ([#93](https://github.com/MetaMask/test-dapp/pull/93))
 
-[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v9.7.0...HEAD
+[Unreleased]: https://github.com/MetaMask/test-dapp/compare/v9.9.0...HEAD
+[9.9.0]: https://github.com/MetaMask/test-dapp/compare/v9.8.0...v9.9.0
+[9.8.0]: https://github.com/MetaMask/test-dapp/compare/v9.7.0...v9.8.0
 [9.7.0]: https://github.com/MetaMask/test-dapp/compare/v9.6.0...v9.7.0
 [9.6.0]: https://github.com/MetaMask/test-dapp/compare/v9.5.0...v9.6.0
 [9.5.0]: https://github.com/MetaMask/test-dapp/compare/v9.4.0...v9.5.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp",
-  "version": "9.8.0",
+  "version": "9.9.0",
   "description": "A simple dapp used in MetaMask e2e tests.",
   "engines": {
     "node": ">= 18.0.0"


### PR DESCRIPTION
This is the release candidate PR for v9.9.0.

### Added
- Add Tempo to the network picker ([#429](https://github.com/MetaMask/test-dapp/pull/429))
- Add Tempo panel with batch tx ([#427](https://github.com/MetaMask/test-dapp/pull/427))
- Add transaction data for EIP5792 sendCalls ([#428](https://github.com/MetaMask/test-dapp/pull/428))
- Add HyperEVM, MegaETH and Monad to the network picker ([#426](https://github.com/MetaMask/test-dapp/pull/426))

### Changed
- Change Tempo default ERC20 address to a Mainnet address ([#430](https://github.com/MetaMask/test-dapp/pull/430))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates `package.json` version and `CHANGELOG.md` entries/compare links with no runtime code changes.
> 
> **Overview**
> Cuts the `9.9.0` release by bumping `package.json` from `9.8.0` to `9.9.0` and adding a `9.9.0` section to `CHANGELOG.md`.
> 
> Updates changelog compare links so `[Unreleased]` now compares from `v9.9.0` and adds the `v9.8.0...v9.9.0` link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5156d2707246058398a0d3302d81715362ff4ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->